### PR TITLE
[3/N][VirtualCluster] pass virtual cluster id to gcs when submitting job

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -122,6 +122,8 @@ RAY_RUNTIME_ENV_CREATE_WORKING_DIR_ENV_VAR = "RAY_RUNTIME_ENV_CREATE_WORKING_DIR
 # the local working_dir and py_modules to be uploaded, or these files might get
 # garbage collected before the job starts.
 RAY_RUNTIME_ENV_URI_PIN_EXPIRATION_S_DEFAULT = 10 * 60
+# Environment variable to specify the virtual cluster ID a Ray job belongs to.
+RAY_VIRTUAL_CLUSTER_ID_ENV_VAR = "VIRTUAL_CLUSTER_ID"
 # If set to 1, then `.gitignore` files will not be parsed and loaded into "excludes"
 # when using a local working_dir or py_modules.
 RAY_RUNTIME_ENV_IGNORE_GITIGNORE = "RAY_RUNTIME_ENV_IGNORE_GITIGNORE"

--- a/python/ray/dashboard/modules/job/common.py
+++ b/python/ray/dashboard/modules/job/common.py
@@ -426,6 +426,8 @@ class JobSubmitRequest:
     # to reserve for the entrypoint command, separately from any Ray tasks
     # or actors that are created by it.
     entrypoint_resources: Optional[Dict[str, float]] = None
+    # Optional virtual cluster ID for job.
+    virtual_cluster_id: Optional[str] = None
 
     def __post_init__(self):
         if not isinstance(self.entrypoint, str):
@@ -510,6 +512,14 @@ class JobSubmitRequest:
                             "entrypoint_resources values must be numbers, "
                             f"got {type(v)}"
                         )
+
+        if self.virtual_cluster_id is not None and not isinstance(
+            self.virtual_cluster_id, str
+        ):
+            raise TypeError(
+                "virtual_cluster_id must be a string if provided, "
+                f"got {type(self.virtual_cluster_id)}"
+            )
 
 
 @dataclass

--- a/python/ray/dashboard/modules/job/job_agent.py
+++ b/python/ray/dashboard/modules/job/job_agent.py
@@ -47,6 +47,7 @@ class JobAgent(dashboard_utils.DashboardAgentModule):
                 submission_id=request_submission_id,
                 runtime_env=submit_request.runtime_env,
                 metadata=submit_request.metadata,
+                virtual_cluster_id=submit_request.virtual_cluster_id,
                 entrypoint_num_cpus=submit_request.entrypoint_num_cpus,
                 entrypoint_num_gpus=submit_request.entrypoint_num_gpus,
                 entrypoint_memory=submit_request.entrypoint_memory,

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -535,7 +535,6 @@ class JobManager:
                 )
 
             driver_logger.info("Runtime env is setting up.")
-
             supervisor = self._supervisor_actor_cls.options(
                 lifetime="detached",
                 name=JOB_ACTOR_NAME_TEMPLATE.format(job_id=submission_id),

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -536,10 +536,6 @@ class JobManager:
 
             driver_logger.info("Runtime env is setting up.")
 
-            virtual_cluster_metadata = {}
-            if virtual_cluster_id is not None:
-                virtual_cluster_metadata["virtual_cluster_id"] = virtual_cluster_id
-
             supervisor = self._supervisor_actor_cls.options(
                 lifetime="detached",
                 name=JOB_ACTOR_NAME_TEMPLATE.format(job_id=submission_id),
@@ -551,7 +547,6 @@ class JobManager:
                 runtime_env=self._get_supervisor_runtime_env(
                     runtime_env, submission_id, resources_specified, virtual_cluster_id
                 ),
-                _metadata=virtual_cluster_metadata,
                 namespace=SUPERVISOR_ACTOR_RAY_NAMESPACE,
             ).remote(
                 submission_id,

--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -56,6 +56,9 @@ constexpr int kPublicDNSServerPort = 53;
 constexpr char kEnvVarKeyJobId[] = "RAY_JOB_ID";
 constexpr char kEnvVarKeyRayletPid[] = "RAY_RAYLET_PID";
 
+// Environment variable key for virtual cluster ID
+constexpr char kEnvVarKeyVirtualClusterID[] = "VIRTUAL_CLUSTER_ID";
+
 /// for cross-langueage serialization
 constexpr int kMessagePackOffset = 9;
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -924,8 +924,14 @@ void CoreWorker::ConnectToRayletInternal() {
   // NOTE: This also marks the worker as available in Raylet. We do this at the
   // very end in case there is a problem during construction.
   if (options_.worker_type == WorkerType::DRIVER) {
+    // Get the virtual cluster ID from environment variables, default to empty string if
+    // not set.
+    const char *virtual_cluster_id = std::getenv(kEnvVarKeyVirtualClusterID);
+    if (virtual_cluster_id == nullptr) {
+      virtual_cluster_id = "";
+    }
     Status status = local_raylet_client_->AnnounceWorkerPortForDriver(
-        core_worker_server_->GetPort(), options_.entrypoint);
+        core_worker_server_->GetPort(), options_.entrypoint, virtual_cluster_id);
     RAY_CHECK(status.ok()) << "Failed to announce driver's port to raylet and GCS: "
                            << status;
   } else {

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -87,7 +87,8 @@ void GcsJobManager::HandleAddJob(rpc::AddJobRequest request,
   mutable_job_table_data.set_start_time(time);
   mutable_job_table_data.set_timestamp(time);
   const JobID job_id = JobID::FromBinary(mutable_job_table_data.job_id());
-  RAY_LOG(INFO) << "Adding job, job id = " << job_id
+  RAY_LOG(INFO) << "Adding job, job id = " << job_id << ", virtual cluster id = "
+                << mutable_job_table_data.virtual_cluster_id()
                 << ", driver pid = " << mutable_job_table_data.driver_pid();
 
   auto on_done = [this,

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -703,5 +703,7 @@ message JobTableData {
   optional bool is_running_tasks = 11;
   // Address of the driver that started this job.
   Address driver_address = 12;
+  // The virtual cluster this job belongs to
+  string virtual_cluster_id = 13;
 }
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -149,6 +149,8 @@ table AnnounceWorkerPort {
   port: int;
   // The entrypoint of the job. Only populated if the worker is a driver.
   entrypoint: string;
+  // The virtual cluster id of this job
+  virtual_cluster_id: string;
 }
 
 table AnnounceWorkerPortReply {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1425,6 +1425,9 @@ void NodeManager::ProcessAnnounceWorkerPortMessage(
                                 string_from_flatbuf(*message->entrypoint()),
                                 *job_config);
 
+    job_data_ptr->set_virtual_cluster_id(
+        string_from_flatbuf(*message->virtual_cluster_id()));
+
     RAY_CHECK_OK(
         gcs_client_->Jobs().AsyncAdd(job_data_ptr, [this, client](Status status) {
           if (!status.ok()) {

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -205,11 +205,11 @@ Status raylet::RayletClient::AnnounceWorkerPortForWorker(int port) {
   return conn_->WriteMessage(MessageType::AnnounceWorkerPort, &fbb);
 }
 
-Status raylet::RayletClient::AnnounceWorkerPortForDriver(int port,
-                                                         const std::string &entrypoint) {
+Status raylet::RayletClient::AnnounceWorkerPortForDriver(
+    int port, const std::string &entrypoint, const std::string &virtual_cluster_id) {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message =
-      protocol::CreateAnnounceWorkerPort(fbb, port, fbb.CreateString(entrypoint));
+  auto message = protocol::CreateAnnounceWorkerPort(
+      fbb, port, fbb.CreateString(entrypoint), fbb.CreateString(virtual_cluster_id));
   fbb.Finish(message);
   std::vector<uint8_t> reply;
   RAY_RETURN_NOT_OK(conn_->AtomicRequestReply(MessageType::AnnounceWorkerPort,

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -358,7 +358,9 @@ class RayletClient : public RayletClientInterface {
   /// \param port The port.
   /// \param entrypoint The entrypoint of the driver's job.
   /// \return ray::Status.
-  Status AnnounceWorkerPortForDriver(int port, const std::string &entrypoint);
+  Status AnnounceWorkerPortForDriver(int port,
+                                     const std::string &entrypoint,
+                                     const std::string &virtual_cluster_id);
 
   /// Tell the raylet that the client has finished executing a task.
   ///


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR is 3/N implementation of the VirtualCluster (see issue https://github.com/antgroup/ant-ray/issues/409) , it just pass virtual cluster id to gcs when submitting job
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
