### PR TITLE
[7/N][VirtualCluster] remove virtual cluster name

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.cc
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.cc
@@ -163,7 +163,6 @@ bool VirtualCluster::MarkNodeInstanceAsDead(const std::string &template_id,
 std::shared_ptr<rpc::VirtualClusterTableData> VirtualCluster::ToProto() const {
   auto data = std::make_shared<rpc::VirtualClusterTableData>();
   data->set_id(GetID());
-  data->set_name(GetName());
   data->set_mode(GetMode());
   data->set_revision(GetRevision());
   data->mutable_replica_sets()->insert(replica_sets_.begin(), replica_sets_.end());
@@ -237,7 +236,7 @@ Status JobClusterManager::CreateJobCluster(
                       std::move(replica_instances_to_remove_from_current_cluster));
 
   // Create a job cluster.
-  auto job_cluster = std::make_shared<JobCluster>(job_cluster_id, job_cluster_id);
+  auto job_cluster = std::make_shared<JobCluster>(job_cluster_id);
   job_cluster->UpdateNodeInstances(std::move(replica_instances_to_add),
                                    ReplicaInstances());
   RAY_CHECK(job_clusters_.emplace(job_cluster_id, job_cluster).second);

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
@@ -104,9 +104,6 @@ class VirtualCluster {
   /// Get the id of the cluster.
   virtual const std::string &GetID() const = 0;
 
-  /// Get the id of the cluster.
-  virtual const std::string &GetName() const = 0;
-
   /// Get the allocation mode of the cluster.
   /// There are two modes of the cluster:
   ///  - Exclusive mode means that a signle node in the cluster can execute one or
@@ -228,7 +225,6 @@ class PrimaryCluster : public JobClusterManager {
 
   const std::string &GetID() const override { return kPrimaryClusterID; }
   rpc::AllocationMode GetMode() const override { return rpc::AllocationMode::Exclusive; }
-  const std::string &GetName() const override { return kPrimaryClusterID; }
 
   /// Create or update a new virtual cluster.
   ///
@@ -283,13 +279,12 @@ class LogicalCluster : public JobClusterManager {
                  const std::string &id,
                  const std::string &name,
                  rpc::AllocationMode mode)
-      : JobClusterManager(async_data_flusher), id_(id), name_(name), mode_(mode) {}
+      : JobClusterManager(async_data_flusher), id_(id), mode_(mode) {}
 
   LogicalCluster &operator=(const LogicalCluster &) = delete;
 
   const std::string &GetID() const override { return id_; }
   rpc::AllocationMode GetMode() const override { return mode_; }
-  const std::string &GetName() const override { return name_; }
 
  protected:
   bool IsIdleNodeInstance(const std::string &job_cluster_id,
@@ -298,19 +293,16 @@ class LogicalCluster : public JobClusterManager {
  private:
   /// The id of the virtual cluster.
   std::string id_;
-  /// The name of the virtual cluster.
-  std::string name_;
   /// The allocation mode of the virtual cluster.
   rpc::AllocationMode mode_;
 };
 
 class JobCluster : public VirtualCluster {
  public:
-  JobCluster(const std::string &id, const std::string &name) : id_(id), name_(name) {}
+  JobCluster(const std::string &id) : id_(id) {}
 
   const std::string &GetID() const override { return id_; }
   rpc::AllocationMode GetMode() const override { return rpc::AllocationMode::Mixed; }
-  const std::string &GetName() const override { return id_; }
 
   bool IsIdleNodeInstance(const std::string &job_cluster_id,
                           const gcs::NodeInstance &node_instance) const override;
@@ -318,8 +310,6 @@ class JobCluster : public VirtualCluster {
  private:
   /// The id of the job cluster.
   std::string id_;
-  /// The name of the job cluster.
-  std::string name_;
 };
 
 }  // namespace gcs

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -727,16 +727,14 @@ message NodeInstance {
 message VirtualClusterTableData {
   // The virtual cluster id.
   string id = 1;
-  // The virtual cluster name.
-  string name = 2;
   // The allocation mode of the virtual cluster.
-  AllocationMode mode = 3;
+  AllocationMode mode = 2;
   // The replica set list of the virtual cluster.
-  map<string, int32> replica_sets = 4;
+  map<string, int32> replica_sets = 3;
   // Mapping from node id to it's instance.
-  map<string, NodeInstance> node_instances = 5;
+  map<string, NodeInstance> node_instances = 4;
   // Whether this virtual cluster is removed.
-  bool is_removed = 6;
+  bool is_removed = 5;
   // Version number of the last modification to the virtual cluster.
-  uint64 revision = 7;
+  uint64 revision = 6;
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR is 7/N implementation of the VirtualCluster (see issue https://github.com/antgroup/ant-ray/issues/409) , it just remove virtual cluster name.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
