### PR TITLE
[11/N][VirtualCluster] Add VirtualClusterInfoAccessor

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1973,6 +1973,7 @@ ray_cc_library(
     name = "gcs_client_lib",
     srcs = [
         "src/ray/gcs/gcs_client/accessor.cc",
+        "src/ray/gcs/gcs_client/accessor.ant.cc",
         "src/ray/gcs/gcs_client/gcs_client.cc",
     ],
     hdrs = [

--- a/src/mock/ray/gcs/gcs_client/accessor.h
+++ b/src/mock/ray/gcs/gcs_client/accessor.h
@@ -352,3 +352,28 @@ class MockInternalKVAccessor : public InternalKVAccessor {
 
 }  // namespace gcs
 }  // namespace ray
+
+namespace ray {
+namespace gcs {
+
+class MockVirtualClusterInfoAccessor : public VirtualClusterInfoAccessor {
+ public:
+  MOCK_METHOD(Status,
+              AsyncGet,
+              (const VirtualClusterID &virtual_cluster_id,
+               const OptionalItemCallback<rpc::VirtualClusterTableData> &callback),
+              (override));
+  MOCK_METHOD(Status,
+              AsyncGetAll,
+              (const MultiItemCallback<rpc::VirtualClusterTableData> &callback),
+              (override));
+  MOCK_METHOD(Status,
+              AsyncSubscribeAll,
+              ((const SubscribeCallback<VirtualClusterID, rpc::VirtualClusterTableData>
+                    &subscribe),
+               const StatusCallback &done),
+              (override));
+};
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/mock/ray/gcs/gcs_client/gcs_client.h
+++ b/src/mock/ray/gcs/gcs_client/gcs_client.h
@@ -50,6 +50,7 @@ class MockGcsClient : public GcsClient {
     mock_placement_group_accessor = new MockPlacementGroupInfoAccessor();
     mock_internal_kv_accessor = new MockInternalKVAccessor();
     mock_task_accessor = new MockTaskInfoAccessor();
+    mock_virtual_cluster_accessor = new MockVirtualClusterInfoAccessor();
 
     GcsClient::job_accessor_.reset(mock_job_accessor);
     GcsClient::actor_accessor_.reset(mock_actor_accessor);
@@ -59,6 +60,7 @@ class MockGcsClient : public GcsClient {
     GcsClient::worker_accessor_.reset(mock_worker_accessor);
     GcsClient::placement_group_accessor_.reset(mock_placement_group_accessor);
     GcsClient::task_accessor_.reset(mock_task_accessor);
+    GcsClient::virtual_cluster_accessor_.reset(mock_virtual_cluster_accessor);
   }
   MockActorInfoAccessor *mock_actor_accessor;
   MockJobInfoAccessor *mock_job_accessor;
@@ -69,6 +71,7 @@ class MockGcsClient : public GcsClient {
   MockPlacementGroupInfoAccessor *mock_placement_group_accessor;
   MockInternalKVAccessor *mock_internal_kv_accessor;
   MockTaskInfoAccessor *mock_task_accessor;
+  MockVirtualClusterInfoAccessor *mock_virtual_cluster_accessor;
 };
 
 }  // namespace gcs

--- a/src/ray/common/virtual_cluster_id.h
+++ b/src/ray/common/virtual_cluster_id.h
@@ -51,6 +51,11 @@ inline std::ostream &operator<<(std::ostream &os, const ray::VirtualClusterID &i
   return os;
 }
 
+template <>
+struct DefaultLogKey<VirtualClusterID> {
+  constexpr static std::string_view key = kLogKeyVirtualClusterID;
+};
+
 }  // namespace ray
 
 namespace std {

--- a/src/ray/gcs/gcs_client/accessor.ant.cc
+++ b/src/ray/gcs/gcs_client/accessor.ant.cc
@@ -1,0 +1,92 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/gcs/gcs_client/accessor.h"
+
+#include <future>
+
+#include "ray/gcs/gcs_client/gcs_client.h"
+
+namespace ray {
+namespace gcs {
+
+VirtualClusterInfoAccessor::VirtualClusterInfoAccessor(GcsClient *client_impl)
+    : client_impl_(client_impl) {}
+
+Status VirtualClusterInfoAccessor::AsyncGet(
+    const VirtualClusterID &virtual_cluster_id,
+    const OptionalItemCallback<rpc::VirtualClusterTableData> &callback) {
+  RAY_LOG(DEBUG).WithField(virtual_cluster_id) << "Getting virtual cluster info";
+  rpc::GetVirtualClustersRequest request;
+  request.set_virtual_cluster_id(virtual_cluster_id.Binary());
+  client_impl_->GetGcsRpcClient().GetVirtualClusters(
+      request,
+      [virtual_cluster_id, callback](const Status &status,
+                                     rpc::GetVirtualClustersReply &&reply) {
+        if (reply.virtual_cluster_data_list_size() == 0) {
+          callback(status, std::nullopt);
+        } else {
+          RAY_CHECK(reply.virtual_cluster_data_list_size() == 1);
+          callback(status, reply.virtual_cluster_data_list().at(0));
+        }
+        RAY_LOG(DEBUG).WithField(virtual_cluster_id)
+            << "Finished getting virtual cluster info";
+      });
+  return Status::OK();
+}
+
+Status VirtualClusterInfoAccessor::AsyncGetAll(
+    const MultiItemCallback<rpc::VirtualClusterTableData> &callback) {
+  RAY_LOG(DEBUG) << "Getting all virtual cluster info.";
+  rpc::GetVirtualClustersRequest request;
+  request.set_include_job_clusters(true);
+  client_impl_->GetGcsRpcClient().GetVirtualClusters(
+      request, [callback](const Status &status, rpc::GetVirtualClustersReply &&reply) {
+        callback(
+            status,
+            VectorFromProtobuf(std::move(*reply.mutable_virtual_cluster_data_list())));
+        RAY_LOG(DEBUG) << "Finished getting all virtual cluster info, status = "
+                       << status;
+      });
+  return Status::OK();
+}
+
+Status VirtualClusterInfoAccessor::AsyncSubscribeAll(
+    const SubscribeCallback<VirtualClusterID, rpc::VirtualClusterTableData> &subscribe,
+    const StatusCallback &done) {
+  RAY_CHECK(subscribe != nullptr);
+  fetch_all_data_operation_ = [this, subscribe](const StatusCallback &done) {
+    auto callback =
+        [subscribe, done](
+            const Status &status,
+            std::vector<rpc::VirtualClusterTableData> &&virtual_cluster_info_list) {
+          for (auto &virtual_cluster_info : virtual_cluster_info_list) {
+            subscribe(VirtualClusterID::FromBinary(virtual_cluster_info.id()),
+                      std::move(virtual_cluster_info));
+          }
+          if (done) {
+            done(status);
+          }
+        };
+    RAY_CHECK_OK(AsyncGetAll(callback));
+  };
+  subscribe_operation_ = [this, subscribe](const StatusCallback &done) {
+    return client_impl_->GetGcsSubscriber().SubscribeAllVirtualClusters(subscribe, done);
+  };
+  return subscribe_operation_(
+      [this, done](const Status &status) { fetch_all_data_operation_(done); });
+}
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -18,6 +18,7 @@
 #include "ray/common/id.h"
 #include "ray/common/placement_group.h"
 #include "ray/common/task/task_spec.h"
+#include "ray/common/virtual_cluster_id.h"
 #include "ray/gcs/callback.h"
 #include "ray/rpc/client_call.h"
 #include "ray/util/sequencer.h"
@@ -993,6 +994,48 @@ class AutoscalerStateAccessor {
                            std::string &rejection_reason_message);
 
  private:
+  GcsClient *client_impl_;
+};
+
+class VirtualClusterInfoAccessor {
+ public:
+  VirtualClusterInfoAccessor() = default;
+  explicit VirtualClusterInfoAccessor(GcsClient *client_impl);
+  virtual ~VirtualClusterInfoAccessor() = default;
+
+  /// Get a virtual cluster data from GCS asynchronously by id.
+  ///
+  /// \param virtual_cluster_id The id of a virtual cluster to obtain from GCS.
+  /// \return Status.
+  virtual Status AsyncGet(
+      const VirtualClusterID &virtual_cluster_id,
+      const OptionalItemCallback<rpc::VirtualClusterTableData> &callback);
+
+  /// Get all virtual cluster info from GCS asynchronously.
+  ///
+  /// \param callback Callback that will be called after lookup finished.
+  /// \return Status
+  virtual Status AsyncGetAll(
+      const MultiItemCallback<rpc::VirtualClusterTableData> &callback);
+
+  /// Subscribe to virtual cluster updates.
+  ///
+  /// \param subscribe Callback that will be called each time when a job updates.
+  /// \param done Callback that will be called when subscription is complete.
+  /// \return Status
+  virtual Status AsyncSubscribeAll(
+      const SubscribeCallback<VirtualClusterID, rpc::VirtualClusterTableData> &subscribe,
+      const StatusCallback &done);
+
+ private:
+  /// Save the fetch data operation in this function, so we can call it again when GCS
+  /// server restarts from a failure.
+  FetchDataOperation fetch_all_data_operation_;
+
+  /// Save the subscribe operation in this function, so we can call it again when PubSub
+  /// server restarts from a failure.
+  SubscribeOperation subscribe_operation_;
+
   GcsClient *client_impl_;
 };
 

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -156,6 +156,7 @@ Status GcsClient::Connect(instrumented_io_context &io_service, int64_t timeout_m
   task_accessor_ = std::make_unique<TaskInfoAccessor>(this);
   runtime_env_accessor_ = std::make_unique<RuntimeEnvAccessor>(this);
   autoscaler_state_accessor_ = std::make_unique<AutoscalerStateAccessor>(this);
+  virtual_cluster_accessor_ = std::make_unique<VirtualClusterInfoAccessor>(this);
 
   RAY_LOG(DEBUG) << "GcsClient connected " << options_.gcs_address_ << ":"
                  << options_.gcs_port_;

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -209,6 +209,11 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
     return *autoscaler_state_accessor_;
   }
 
+  VirtualClusterInfoAccessor &VirtualCluster() {
+    RAY_CHECK(virtual_cluster_accessor_ != nullptr);
+    return *virtual_cluster_accessor_;
+  }
+
   // Gets ClusterID. If it's not set in Connect(), blocks on a sync RPC to GCS to get it.
   virtual ClusterID GetClusterId() const;
 
@@ -234,6 +239,7 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
   std::unique_ptr<TaskInfoAccessor> task_accessor_;
   std::unique_ptr<RuntimeEnvAccessor> runtime_env_accessor_;
   std::unique_ptr<AutoscalerStateAccessor> autoscaler_state_accessor_;
+  std::unique_ptr<VirtualClusterInfoAccessor> virtual_cluster_accessor_;
 
  private:
   /// If client_call_manager_ does not have a cluster ID, fetches it from GCS. The

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -865,6 +865,6 @@ service VirtualClusterInfoGcsService {
       returns (CreateOrUpdateVirtualClusterReply);
   // Remove a virtual cluster.
   rpc RemoveVirtualCluster(RemoveVirtualClusterRequest) returns (RemoveVirtualClusterReply);
-  // Get all the virtual clusters.
+  // Get virtual clusters.
   rpc GetVirtualClusters(GetVirtualClustersRequest) returns (GetVirtualClustersReply);
 }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -500,6 +500,18 @@ ray::Status NodeManager::RegisterGcs() {
   RAY_RETURN_NOT_OK(
       gcs_client_->Jobs().AsyncSubscribeAll(job_subscribe_handler, nullptr));
 
+  // Subscribe to all virtual clusrter update notification.
+  const auto virtual_cluster_update_notification_handler =
+      [this](const VirtualClusterID &virtual_cluster_id,
+             const rpc::VirtualClusterTableData &virtual_cluster_data) {
+        // TODO(Shanly): To be implemented.
+      };
+  RAY_RETURN_NOT_OK(gcs_client_->VirtualCluster().AsyncSubscribeAll(
+      virtual_cluster_update_notification_handler, [](const ray::Status &status) {
+        RAY_CHECK_OK(status);
+        RAY_LOG(INFO) << "Finished subscribing all virtual cluster infos.";
+      }));
+
   periodical_runner_->RunFnPeriodically(
       [this] {
         DumpDebugState();

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -178,6 +178,10 @@ class GcsRpcClient {
     runtime_env_grpc_client_ =
         std::make_shared<GrpcClient<RuntimeEnvGcsService>>(channel_, client_call_manager);
 
+    virtual_cluster_info_grpc_client_ =
+        std::make_shared<GrpcClient<VirtualClusterInfoGcsService>>(channel_,
+                                                                   client_call_manager);
+
     retryable_grpc_client_ = RetryableGrpcClient::Create(
         channel_,
         client_call_manager.GetMainService(),
@@ -549,6 +553,24 @@ class GcsRpcClient {
                              runtime_env_grpc_client_,
                              /*method_timeout_ms*/ -1, )
 
+  // Create or update a virtual cluster.
+  VOID_GCS_RPC_CLIENT_METHOD(VirtualClusterInfoGcsService,
+                             CreateOrUpdateVirtualCluster,
+                             virtual_cluster_info_grpc_client_,
+                             /*method_timeout_ms*/ -1, )
+
+  // Remove a virtual cluster.
+  VOID_GCS_RPC_CLIENT_METHOD(VirtualClusterInfoGcsService,
+                             RemoveVirtualCluster,
+                             virtual_cluster_info_grpc_client_,
+                             /*method_timeout_ms*/ -1, )
+
+  // Get virtual clusters.
+  VOID_GCS_RPC_CLIENT_METHOD(VirtualClusterInfoGcsService,
+                             GetVirtualClusters,
+                             virtual_cluster_info_grpc_client_,
+                             /*method_timeout_ms*/ -1, )
+
   std::pair<std::string, int64_t> GetAddress() const {
     return std::make_pair(gcs_address_, gcs_port_);
   }
@@ -575,6 +597,8 @@ class GcsRpcClient {
   std::shared_ptr<GrpcClient<RuntimeEnvGcsService>> runtime_env_grpc_client_;
   std::shared_ptr<GrpcClient<autoscaler::AutoscalerStateService>>
       autoscaler_state_grpc_client_;
+  std::shared_ptr<GrpcClient<VirtualClusterInfoGcsService>>
+      virtual_cluster_info_grpc_client_;
 
   friend class GcsClientReconnectionTest;
   FRIEND_TEST(GcsClientReconnectionTest, ReconnectionBackoff);

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -101,6 +101,7 @@ inline constexpr std::string_view kLogKeyActorID = "actor_id";
 inline constexpr std::string_view kLogKeyTaskID = "task_id";
 inline constexpr std::string_view kLogKeyObjectID = "object_id";
 inline constexpr std::string_view kLogKeyPlacementGroupID = "placement_group_id";
+inline constexpr std::string_view kLogKeyVirtualClusterID = "virtual_cluster_id";
 
 // Define your specialization DefaultLogKey<your_type>::key to get .WithField(t)
 // See src/ray/common/id.h


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is 11/N implementation of the VirtualCluster (see issue https://github.com/antgroup/ant-ray/issues/409) , it adds `VirtualClusterInfoAccessor`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
