### PR TITLE
[14/N][VirtualCluster] Raylet only subscribe mixed cluster data.

### DIFF
--- a/src/mock/ray/gcs/gcs_client/accessor.h
+++ b/src/mock/ray/gcs/gcs_client/accessor.h
@@ -365,7 +365,9 @@ class MockVirtualClusterInfoAccessor : public VirtualClusterInfoAccessor {
               (override));
   MOCK_METHOD(Status,
               AsyncGetAll,
-              (const MultiItemCallback<rpc::VirtualClusterTableData> &callback),
+              (bool include_job_clusters,
+               bool only_include_mixed_clusters,
+               (const MultiItemCallback<rpc::VirtualClusterTableData> &callback)),
               (override));
   MOCK_METHOD(Status,
               AsyncSubscribeAll,

--- a/src/ray/gcs/gcs_client/accessor.ant.cc
+++ b/src/ray/gcs/gcs_client/accessor.ant.cc
@@ -47,10 +47,13 @@ Status VirtualClusterInfoAccessor::AsyncGet(
 }
 
 Status VirtualClusterInfoAccessor::AsyncGetAll(
+    bool include_job_clusters,
+    bool only_include_mixed_clusters,
     const MultiItemCallback<rpc::VirtualClusterTableData> &callback) {
   RAY_LOG(DEBUG) << "Getting all virtual cluster info.";
   rpc::GetVirtualClustersRequest request;
   request.set_include_job_clusters(true);
+  request.set_only_include_mixed_clusters(true);
   client_impl_->GetGcsRpcClient().GetVirtualClusters(
       request, [callback](const Status &status, rpc::GetVirtualClustersReply &&reply) {
         callback(
@@ -79,7 +82,10 @@ Status VirtualClusterInfoAccessor::AsyncSubscribeAll(
             done(status);
           }
         };
-    RAY_CHECK_OK(AsyncGetAll(callback));
+    RAY_CHECK_OK(AsyncGetAll(
+        /*include_job_clusters=*/true,
+        /*only_include_mixed_clusters=*/true,
+        callback));
   };
   subscribe_operation_ = [this, subscribe](const StatusCallback &done) {
     return client_impl_->GetGcsSubscriber().SubscribeAllVirtualClusters(subscribe, done);

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -1016,6 +1016,8 @@ class VirtualClusterInfoAccessor {
   /// \param callback Callback that will be called after lookup finished.
   /// \return Status
   virtual Status AsyncGetAll(
+      bool include_job_clusters,
+      bool only_include_mixed_clusters,
       const MultiItemCallback<rpc::VirtualClusterTableData> &callback);
 
   /// Subscribe to virtual cluster updates.

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.cc
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.cc
@@ -519,6 +519,7 @@ void PrimaryCluster::GetVirtualClustersData(rpc::GetVirtualClustersRequest reque
   std::vector<std::shared_ptr<rpc::VirtualClusterTableData>> virtual_cluster_data_list;
   auto virtual_cluster_id = request.virtual_cluster_id();
   bool include_job_clusters = request.include_job_clusters();
+  bool only_include_mixed_cluster = request.only_include_mixed_clusters();
 
   auto visit_proto_data = [&](const VirtualCluster *cluster) {
     if (include_job_clusters && cluster->GetMode() == rpc::AllocationMode::EXCLUSIVE) {
@@ -527,6 +528,10 @@ void PrimaryCluster::GetVirtualClustersData(rpc::GetVirtualClustersRequest reque
           [&](const std::string &_, const auto &job_cluster) {
             callback(job_cluster->ToProto());
           });
+    }
+    if (only_include_mixed_cluster &&
+        cluster->GetMode() == rpc::AllocationMode::EXCLUSIVE) {
+      return;
     }
     if (cluster->GetID() != kPrimaryClusterID) {
       // Skip the primary cluster's proto data.

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.cc
@@ -216,6 +216,12 @@ Status GcsVirtualClusterManager::FlushAndPublish(
   auto on_done = [this, data, callback = std::move(callback)](const Status &status) {
     // The backend storage is supposed to be reliable, so the status must be ok.
     RAY_CHECK_OK(status);
+    if (data->mode() != rpc::AllocationMode::MIXED) {
+      // Tasks can only be scheduled on the nodes in the mixed cluster, so we just need to
+      // publish the mixed cluster data.
+      return;
+    }
+
     RAY_CHECK_OK(gcs_publisher_.PublishVirtualCluster(
         VirtualClusterID::FromBinary(data->id()), *data, nullptr));
     if (callback) {

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -852,6 +852,8 @@ message GetVirtualClustersRequest {
   string virtual_cluster_id = 1;
   // Wether include job clusters.
   bool include_job_clusters = 2;
+  // It will reply mixed clusters if only_include_mixed_clusters is true.
+  bool only_include_mixed_clusters = 3;
 }
 
 message GetVirtualClustersReply {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is 14/N implementation of the VirtualCluster (see issue https://github.com/antgroup/ant-ray/issues/409) , Raylet only subscribe mixed cluster data.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
