### PR TITLE
[15/N][VirtualCluster] Complete scheduling for mixed virtual cluster

### DIFF
--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -534,6 +534,10 @@ class JobManager:
                     f"Started a ray job {submission_id}.", submission_id=submission_id
                 )
 
+            labels = {}
+            if virtual_cluster_id is not None:
+                labels["virtual_cluster_id"] = virtual_cluster_id
+
             driver_logger.info("Runtime env is setting up.")
             supervisor = self._supervisor_actor_cls.options(
                 lifetime="detached",
@@ -547,6 +551,7 @@ class JobManager:
                     runtime_env, submission_id, resources_specified, virtual_cluster_id
                 ),
                 namespace=SUPERVISOR_ACTOR_RAY_NAMESPACE,
+                _labels=labels,
             ).remote(
                 submission_id,
                 entrypoint,

--- a/python/ray/dashboard/modules/job/tests/test_job_with_virtual_cluster.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_with_virtual_cluster.py
@@ -21,8 +21,6 @@ from ray.cluster_utils import Cluster, cluster_not_supported
 from ray.core.generated import gcs_service_pb2_grpc
 from ray.core.generated.gcs_pb2 import AllocationMode
 from ray.core.generated.gcs_service_pb2 import CreateOrUpdateVirtualClusterRequest
-from ray.dashboard.modules.job.common import JobSubmitRequest, validate_request_type
-from ray.dashboard.modules.job.job_head import JobAgentSubmissionClient
 from ray.dashboard.tests.conftest import *  # noqa
 from ray.job_submission import JobSubmissionClient
 from ray.runtime_env.runtime_env import RuntimeEnv
@@ -97,7 +95,6 @@ async def job_sdk_client(request, make_sure_dashboard_http_port_unused, external
         head_address = res.webui_url
         assert wait_until_server_available(head_address)
         yield (
-            JobAgentSubmissionClient(format_web_url(agent_address)),
             JobSubmissionClient(format_web_url(head_address)),
             res.gcs_address,
             res,
@@ -124,12 +121,15 @@ async def create_virtual_cluster(
 
 @pytest.mark.parametrize(
     "job_sdk_client",
-    [{"_system_config": {"gcs_actor_scheduling_enabled": True}}],
+    [
+        {"_system_config": {"gcs_actor_scheduling_enabled": False}},
+        {"_system_config": {"gcs_actor_scheduling_enabled": True}},
+    ],
     indirect=True,
 )
 @pytest.mark.asyncio
 async def test_mixed_virtual_cluster(job_sdk_client):
-    agent_client, head_client, gcs_address, cluster = job_sdk_client
+    head_client, gcs_address, cluster = job_sdk_client
     virtual_cluster_id_prefix = "VIRTUAL_CLUSTER_"
     node_to_virtual_cluster = {}
     for i in range(NTEMPLATE):
@@ -141,10 +141,32 @@ async def test_mixed_virtual_cluster(job_sdk_client):
             assert node_id not in node_to_virtual_cluster
             node_to_virtual_cluster[node_id] = virtual_cluster_id
 
+    @ray.remote
+    class ControlActor:
+        def __init__(self):
+            self._nodes = set()
+            self._ready = False
+
+        def ready(self):
+            self._ready = True
+
+        def is_ready(self):
+            return self._ready
+
+        def add_node(self, node_id):
+            self._nodes.add(node_id)
+
+        def nodes(self):
+            return self._nodes
+
     for i in range(NTEMPLATE):
         actor_name = f"test_actors_{i}"
         pg_name = f"test_pgs_{i}"
+        control_actor_name = f"control_{i}"
         virtual_cluster_id = virtual_cluster_id_prefix + str(i)
+        control_actor = ControlActor.options(
+            name=control_actor_name, namespace="control"
+        ).remote()
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = Path(tmp_dir)
             driver_script = """
@@ -152,24 +174,45 @@ import ray
 import time
 ray.init(address='auto')
 
+control = ray.get_actor(name="__control_actor_name__", namespace="control")
+
 @ray.remote(max_restarts=10)
 class Actor:
-    def __init__(self):
-        pass
+    def __init__(self, control):
+        node_id = ray.get_runtime_context().get_node_id()
+        ray.get(control.add_node.remote(node_id))
 
-    def run(self):
+    def run(self, control):
+        node_id = ray.get_runtime_context().get_node_id()
+        ray.get(control.add_node.remote(node_id))
+        ray.get(control.ready.remote())
         while True:
             time.sleep(1)
 
 pg = ray.util.placement_group(bundles=[{"CPU": 1}],
         name="__pg_name__", lifetime="detached")
 
-a = Actor.options(name="__actor_name__", num_cpus=1, lifetime="detached").remote()
-print("actor __actor_name__ created", flush=True)
-ray.get(a.run.remote())
+@ray.remote
+def hello(control):
+    node_id = ray.get_runtime_context().get_node_id()
+    ray.get(control.add_node.remote(node_id))
+
+while True:
+    node_id = ray.util.placement_group_table(pg)["bundles_to_node_id"][0]
+    if node_id == "":
+        continue
+    break
+
+ray.get(control.add_node.remote(node_id))
+
+ray.get(hello.remote(control))
+a = Actor.options(name="__actor_name__", num_cpus=1, lifetime="detached").remote(control)
+ray.get(a.run.remote(control))
             """
-            driver_script = driver_script.replace("__actor_name__", actor_name).replace(
-                "__pg_name__", pg_name
+            driver_script = (
+                driver_script.replace("__actor_name__", actor_name)
+                .replace("__pg_name__", pg_name)
+                .replace("__control_actor_name__", control_actor_name)
             )
             test_script_file = path / "test_script.py"
             with open(test_script_file, "w+") as file:
@@ -181,70 +224,37 @@ ray.get(a.run.remote())
             )
             runtime_env = RuntimeEnv(**runtime_env).to_dict()
 
-            request = validate_request_type(
-                {
-                    "runtime_env": runtime_env,
-                    "entrypoint": "python test_script.py",
-                    "virtual_cluster_id": virtual_cluster_id,
-                },
-                JobSubmitRequest,
+            head_client.submit_job(
+                entrypoint="python test_script.py",
+                runtime_env=runtime_env,
+                virtual_cluster_id=virtual_cluster_id,
             )
-            submit_result = await agent_client.submit_job_internal(request)
-            job_id = submit_result.submission_id
 
-            def _check_job_logs(job_id, actor_name):
-                logs = head_client.get_job_logs(job_id)
-                assert f"actor {actor_name} created" in logs
+            def _check_ready(control_actor):
+                return ray.get(control_actor.is_ready.remote())
+
+            wait_for_condition(partial(_check_ready, control_actor), timeout=20)
+
+            def _check_virtual_cluster(
+                control_actor, node_to_virtual_cluster, virtual_cluster_id
+            ):
+                nodes = ray.get(control_actor.nodes.remote())
+                assert len(nodes) > 0
+                for node in nodes:
+                    assert node_to_virtual_cluster[node] == virtual_cluster_id
                 return True
 
             wait_for_condition(
-                partial(_check_job_logs, job_id, actor_name),
-                timeout=100,
-            )
-
-            def _check_actor_alive(
-                actor_name, node_to_virtual_cluster, virtual_cluster_id
-            ):
-                actors = ray.state.actors()
-                for _, actor_info in actors.items():
-                    if actor_info["Name"] == actor_name:
-                        assert actor_info["State"] == "ALIVE"
-                        assert actor_info["NumRestarts"] == 0
-                        node_id = actor_info["Address"]["NodeID"]
-                        assert node_to_virtual_cluster[node_id] == virtual_cluster_id
-                        return True
-                return False
-
-            wait_for_condition(
                 partial(
-                    _check_actor_alive,
-                    actor_name,
+                    _check_virtual_cluster,
+                    control_actor,
                     node_to_virtual_cluster,
                     virtual_cluster_id,
                 ),
-                timeout=100,
+                timeout=20,
             )
 
-            nodes_to_remove = set()
-
-            actors = ray.state.actors()
-            nassert = 0
-            for _, actor_info in actors.items():
-                if actor_info["Name"] == actor_name:
-                    node_id = actor_info["Address"]["NodeID"]
-                    nodes_to_remove.add(node_id)
-                    nassert += 1
-                    assert node_to_virtual_cluster[node_id] == virtual_cluster_id
-            assert nassert > 0
-
-            nassert = 0
-            for _, placement_group_data in ray.util.placement_group_table().items():
-                if placement_group_data["name"] == pg_name:
-                    node_id = placement_group_data["bundles_to_node_id"][0]
-                    nodes_to_remove.add(node_id)
-                    nassert += 1
-                    assert node_to_virtual_cluster[node_id] == virtual_cluster_id
-            assert nassert > 0
+            nodes_to_remove = ray.get(control_actor.nodes.remote())
 
             to_remove = []
             for node in cluster.worker_nodes:

--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -59,6 +59,9 @@ constexpr char kEnvVarKeyRayletPid[] = "RAY_RAYLET_PID";
 // Environment variable key for virtual cluster ID
 constexpr char kEnvVarKeyVirtualClusterID[] = "VIRTUAL_CLUSTER_ID";
 
+// Label key for virtual cluster ID
+constexpr char kLabelVirtualClusterID[] = "virtual_cluster_id";
+
 /// for cross-langueage serialization
 constexpr int kMessagePackOffset = 9;
 

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -273,10 +273,14 @@ class TaskSpecBuilder {
     if (!root_detached_actor_id.IsNil()) {
       message_->set_root_detached_actor_id(root_detached_actor_id.Binary());
     }
+
     // This ensures that actors incorporate virtual cluster information during scheduling.
-    std::string virtual_cluster_id = std::getenv(kEnvVarKeyVirtualClusterID)
-                                         ? std::getenv(kEnvVarKeyVirtualClusterID)
-                                         : "";
+    std::string virtual_cluster_id = message_->labels().contains(kLabelVirtualClusterID)
+                                         ? message_->labels().at(kLabelVirtualClusterID)
+                                         : (std::getenv(kEnvVarKeyVirtualClusterID)
+                                                ? std::getenv(kEnvVarKeyVirtualClusterID)
+                                                : "");
+
     message_->mutable_scheduling_strategy()->set_virtual_cluster_id(virtual_cluster_id);
     return *this;
   }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -322,7 +322,17 @@ NodeManager::NodeManager(
       /*labels*/
       config.labels,
       /*is_node_schedulable_fn=*/
-      [](scheduling::NodeID node_id, const SchedulingContext *context) { return true; });
+      [this](scheduling::NodeID node_id, const SchedulingContext *context) {
+        if (virtual_cluster_manager_ == nullptr) {
+          return true;
+        }
+        if (context->virtual_cluster_id.empty()) {
+          return true;
+        }
+        auto node_instance_id = NodeID::FromBinary(node_id.Binary());
+        return virtual_cluster_manager_->ContainsNodeInstance(context->virtual_cluster_id,
+                                                              node_instance_id);
+      });
 
   auto get_node_info_func = [this](const NodeID &node_id) {
     return gcs_client_->Nodes().Get(node_id);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR is 14/N implementation of the VirtualCluster (see issue https://github.com/antgroup/ant-ray/issues/409) , support raylet-based scheduling for actors, normal tasks, and placement groups in virtual clusters, ensuring supervisor actors are scheduled to their respective clusters and drivers run on the correct virtual clusters.



<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
