### PR TITLE
[16/N][VirtualCluster] Add virtual cluster failover logic

### DIFF
--- a/src/ray/common/virtual_cluster_id.h
+++ b/src/ray/common/virtual_cluster_id.h
@@ -33,7 +33,7 @@ class VirtualClusterID : public SimpleID<VirtualClusterID> {
     return id_.find(kJobClusterIDSeperator) != std::string::npos;
   }
 
-  VirtualClusterID OwnerID() const {
+  VirtualClusterID ParentID() const {
     auto pos = id_.find(kJobClusterIDSeperator);
     return pos == std::string::npos ? Nil()
                                     : VirtualClusterID::FromBinary(id_.substr(0, pos));

--- a/src/ray/gcs/gcs_server/gcs_init_data.h
+++ b/src/ray/gcs/gcs_server/gcs_init_data.h
@@ -64,6 +64,12 @@ class GcsInitData {
     return placement_group_table_data_;
   }
 
+  /// Get virtual cluster metadata.
+  const absl::flat_hash_map<VirtualClusterID, rpc::VirtualClusterTableData>
+      &VirtualClusters() const {
+    return virtual_cluster_table_data_;
+  }
+
  private:
   /// Load job metadata from the store into memory asynchronously.
   ///
@@ -87,6 +93,11 @@ class GcsInitData {
 
   void AsyncLoadActorTaskSpecTableData(const EmptyCallback &on_done);
 
+  /// Load virtual cluster metadata from the store into memory asynchronously.
+  ///
+  /// \param on_done The callback when virtual cluster metadata is loaded successfully.
+  void AsyncLoadVirtualClusterTableData(const EmptyCallback &on_done);
+
  protected:
   /// The gcs table storage.
   gcs::GcsTableStorage &gcs_table_storage_;
@@ -105,6 +116,10 @@ class GcsInitData {
   absl::flat_hash_map<ActorID, rpc::ActorTableData> actor_table_data_;
 
   absl::flat_hash_map<ActorID, rpc::TaskSpec> actor_task_spec_table_data_;
+
+  /// Virtual cluster metadata.
+  absl::flat_hash_map<VirtualClusterID, rpc::VirtualClusterTableData>
+      virtual_cluster_table_data_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.cc
@@ -20,7 +20,7 @@ namespace ray {
 namespace gcs {
 
 void GcsVirtualClusterManager::Initialize(const GcsInitData &gcs_init_data) {
-  // TODO(Shanly): To be implement.
+  primary_cluster_->Initialize(gcs_init_data);
 }
 
 void GcsVirtualClusterManager::OnNodeAdd(const rpc::GcsNodeInfo &node) {
@@ -219,6 +219,9 @@ Status GcsVirtualClusterManager::FlushAndPublish(
     if (data->mode() != rpc::AllocationMode::MIXED) {
       // Tasks can only be scheduled on the nodes in the mixed cluster, so we just need to
       // publish the mixed cluster data.
+      if (callback) {
+        callback(status, std::move(data));
+      }
       return;
     }
 

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -729,12 +729,10 @@ message VirtualClusterTableData {
   string id = 1;
   // The allocation mode of the virtual cluster.
   AllocationMode mode = 2;
-  // The replica set list of the virtual cluster.
-  map<string, int32> replica_sets = 3;
   // Mapping from node id to it's instance.
-  map<string, NodeInstance> node_instances = 4;
+  map<string, NodeInstance> node_instances = 3;
   // Whether this virtual cluster is removed.
-  bool is_removed = 5;
+  bool is_removed = 4;
   // Version number of the last modification to the virtual cluster.
-  uint64 revision = 6;
+  uint64 revision = 5;
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is 13/N implementation of the VirtualCluster (see issue https://github.com/antgroup/ant-ray/issues/409) , it adds failover logic.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
