### PR TITLE
[21/N][VirtualCluster] refactor mixed/exclusive cluster to indivisible/divisible cluster

### DIFF
--- a/python/ray/dashboard/modules/virtual_cluster/virtual_cluster_head.py
+++ b/python/ray/dashboard/modules/virtual_cluster/virtual_cluster_head.py
@@ -5,7 +5,6 @@ import aiohttp.web
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
 from ray.core.generated import gcs_service_pb2_grpc
-from ray.core.generated.gcs_pb2 import AllocationMode
 from ray.core.generated.gcs_service_pb2 import (
     CreateOrUpdateVirtualClusterRequest,
     GetVirtualClustersRequest,
@@ -44,8 +43,8 @@ class VirtualClusterHead(dashboard_utils.DashboardHeadModule):
                 virtual_cluster_data["revision"] = int(
                     virtual_cluster_data.get("revision", 0)
                 )
-                virtual_cluster_data["allocationMode"] = str(
-                    virtual_cluster_data.pop("mode", "mixed")
+                virtual_cluster_data["divisible"] = str(
+                    virtual_cluster_data.pop("divisible", False)
                 ).lower()
 
             return dashboard_optional_utils.rest_response(
@@ -69,16 +68,13 @@ class VirtualClusterHead(dashboard_utils.DashboardHeadModule):
 
         virtual_cluster_info = dict(virtual_cluster_info_json)
         virtual_cluster_id = virtual_cluster_info["virtualClusterId"]
-        allocation_mode = AllocationMode.MIXED
-        if (
-            str(virtual_cluster_info.get("allocationMode", "mixed")).lower()
-            == "exclusive"
-        ):
-            allocation_mode = AllocationMode.EXCLUSIVE
+        divisible = False
+        if str(virtual_cluster_info.get("divisible", False)).lower() == "true":
+            divisible = True
 
         request = CreateOrUpdateVirtualClusterRequest(
             virtual_cluster_id=virtual_cluster_id,
-            mode=allocation_mode,
+            divisible=divisible,
             replica_sets=virtual_cluster_info.get("replicaSets", {}),
             revision=int(virtual_cluster_info.get("revision", 0)),
         )

--- a/src/mock/ray/gcs/gcs_client/accessor.h
+++ b/src/mock/ray/gcs/gcs_client/accessor.h
@@ -366,7 +366,7 @@ class MockVirtualClusterInfoAccessor : public VirtualClusterInfoAccessor {
   MOCK_METHOD(Status,
               AsyncGetAll,
               (bool include_job_clusters,
-               bool only_include_mixed_clusters,
+               bool only_include_indivisible_clusters,
                (const MultiItemCallback<rpc::VirtualClusterTableData> &callback)),
               (override));
   MOCK_METHOD(Status,

--- a/src/ray/gcs/gcs_client/accessor.ant.cc
+++ b/src/ray/gcs/gcs_client/accessor.ant.cc
@@ -48,12 +48,12 @@ Status VirtualClusterInfoAccessor::AsyncGet(
 
 Status VirtualClusterInfoAccessor::AsyncGetAll(
     bool include_job_clusters,
-    bool only_include_mixed_clusters,
+    bool only_include_indivisible_clusters,
     const MultiItemCallback<rpc::VirtualClusterTableData> &callback) {
   RAY_LOG(DEBUG) << "Getting all virtual cluster info.";
   rpc::GetVirtualClustersRequest request;
   request.set_include_job_clusters(true);
-  request.set_only_include_mixed_clusters(true);
+  request.set_only_include_indivisible_clusters(true);
   client_impl_->GetGcsRpcClient().GetVirtualClusters(
       request, [callback](const Status &status, rpc::GetVirtualClustersReply &&reply) {
         callback(
@@ -84,7 +84,7 @@ Status VirtualClusterInfoAccessor::AsyncSubscribeAll(
         };
     RAY_CHECK_OK(AsyncGetAll(
         /*include_job_clusters=*/true,
-        /*only_include_mixed_clusters=*/true,
+        /*only_include_indivisible_clusters=*/true,
         callback));
   };
   subscribe_operation_ = [this, subscribe](const StatusCallback &done) {

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -1017,7 +1017,7 @@ class VirtualClusterInfoAccessor {
   /// \return Status
   virtual Status AsyncGetAll(
       bool include_job_clusters,
-      bool only_include_mixed_clusters,
+      bool only_include_indivisible_clusters,
       const MultiItemCallback<rpc::VirtualClusterTableData> &callback);
 
   /// Subscribe to virtual cluster updates.

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -718,8 +718,7 @@ Status GcsActorManager::RegisterActor(const ray::rpc::RegisterActorRequest &requ
   if (!virtual_cluster_id.empty()) {
     auto virtual_cluster =
         gcs_virtual_cluster_manager_.GetVirtualCluster(virtual_cluster_id);
-    if ((virtual_cluster == nullptr) ||
-        (virtual_cluster->GetMode() == rpc::AllocationMode::EXCLUSIVE)) {
+    if (virtual_cluster == nullptr || virtual_cluster->Divisible()) {
       std::stringstream stream;
       stream << "Invalid virtual cluster, virtual cluster id: " << virtual_cluster_id;
       return Status::InvalidArgument(stream.str());

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -125,8 +125,7 @@ void GcsJobManager::HandleAddJob(rpc::AddJobRequest request,
   if (!virtual_cluster_id.empty()) {
     auto virtual_cluster =
         gcs_virtual_cluster_manager_.GetVirtualCluster(virtual_cluster_id);
-    if ((virtual_cluster == nullptr) ||
-        (virtual_cluster->GetMode() == rpc::AllocationMode::EXCLUSIVE)) {
+    if (virtual_cluster == nullptr || virtual_cluster->Divisible()) {
       std::stringstream stream;
       stream << "Invalid virtual cluster, virtual cluster id: " << virtual_cluster_id;
       auto status = Status::InvalidArgument(stream.str());

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -400,7 +400,7 @@ void GcsServer::InitClusterResourceScheduler() {
         if (virtual_cluster == nullptr) {
           return true;
         }
-        RAY_CHECK(virtual_cluster->GetMode() == rpc::AllocationMode::MIXED);
+        RAY_CHECK(!virtual_cluster->Divisible());
         // Check if the node is contained within the specified virtual cluster.
         return virtual_cluster->ContainsNodeInstance(node_instance_id);
       });

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -714,14 +714,6 @@ message JobTableData {
 }
 ///////////////////////////////////////////////////////////////////////////////
 
-enum AllocationMode {
-  UNKNOWN = 0;
-  // A single node can carray tasks for multiple jobs.
-  MIXED = 1;
-  // A single node can only carray tasks for one job.
-  EXCLUSIVE = 2;
-}
-
 message NodeInstance {
   // The Hostname address of the node instance.
   string hostname = 1;
@@ -732,8 +724,8 @@ message NodeInstance {
 message VirtualClusterTableData {
   // The virtual cluster id.
   string id = 1;
-  // The allocation mode of the virtual cluster.
-  AllocationMode mode = 2;
+  // Whether the virtual cluster can splite into many child virtual clusters or not.
+  bool divisible = 2;
   // Mapping from node id to it's instance.
   map<string, NodeInstance> node_instances = 3;
   // Whether this virtual cluster is removed.

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -866,8 +866,8 @@ service TaskInfoGcsService {
 message CreateOrUpdateVirtualClusterRequest {
   // The virtual cluster id.
   string virtual_cluster_id = 1;
-  // The allocation mode of the virtual cluster.
-  AllocationMode mode = 2;
+  // Whether the virtual cluster can splite into many child virtual clusters or not.
+  bool divisible = 2;
   // The replica set of the virtual cluster.
   map<string, int32> replica_sets = 3;
   // Version number of the last modification to the virtual cluster.
@@ -901,8 +901,8 @@ message GetVirtualClustersRequest {
   string virtual_cluster_id = 1;
   // Wether include job clusters.
   bool include_job_clusters = 2;
-  // It will reply mixed clusters if only_include_mixed_clusters is true.
-  bool only_include_mixed_clusters = 3;
+  // It will reply indivisible clusters if only_include_indivisible_clusters is true.
+  bool only_include_indivisible_clusters = 3;
 }
 
 message GetVirtualClustersReply {

--- a/src/ray/raylet/virtual_cluster_manager.cc
+++ b/src/ray/raylet/virtual_cluster_manager.cc
@@ -22,8 +22,10 @@ namespace raylet {
 bool VirtualClusterManager::UpdateVirtualCluster(
     rpc::VirtualClusterTableData virtual_cluster_data) {
   RAY_LOG(INFO) << "Virtual cluster updated: " << virtual_cluster_data.id();
-  if (virtual_cluster_data.mode() != rpc::AllocationMode::MIXED) {
-    RAY_LOG(WARNING) << "The virtual cluster mode is not MIXED, ignore it.";
+  if (virtual_cluster_data.divisible()) {
+    RAY_LOG(WARNING) << "Virtual cluster " << virtual_cluster_data.id()
+                     << " is divisible, "
+                     << "ignore it.";
     return false;
   }
 
@@ -60,7 +62,7 @@ bool VirtualClusterManager::ContainsNodeInstance(const std::string &virtual_clus
     return false;
   }
   const auto &virtual_cluster_data = it->second;
-  RAY_CHECK(virtual_cluster_data.mode() == rpc::AllocationMode::MIXED);
+  RAY_CHECK(!virtual_cluster_data.divisible());
 
   const auto &node_instances = virtual_cluster_data.node_instances();
   return node_instances.find(node_id.Hex()) != node_instances.end();

--- a/src/ray/raylet/virtual_cluster_manager_test.cc
+++ b/src/ray/raylet/virtual_cluster_manager_test.cc
@@ -31,7 +31,7 @@ TEST_F(VirtualClusterManagerTest, UpdateVirtualCluster) {
 
   rpc::VirtualClusterTableData virtual_cluster_data;
   virtual_cluster_data.set_id(virtual_cluster_id_0);
-  virtual_cluster_data.set_mode(rpc::AllocationMode::EXCLUSIVE);
+  virtual_cluster_data.set_divisible(true);
   virtual_cluster_data.set_revision(100);
   for (size_t i = 0; i < 100; ++i) {
     auto node_id = NodeID::FromRandom();
@@ -41,7 +41,7 @@ TEST_F(VirtualClusterManagerTest, UpdateVirtualCluster) {
   ASSERT_FALSE(virtual_cluster_manager.UpdateVirtualCluster(virtual_cluster_data));
   ASSERT_FALSE(virtual_cluster_manager.ContainsVirtualCluster(virtual_cluster_id_0));
 
-  virtual_cluster_data.set_mode(rpc::AllocationMode::MIXED);
+  virtual_cluster_data.set_divisible(false);
   ASSERT_TRUE(virtual_cluster_manager.UpdateVirtualCluster(virtual_cluster_data));
   ASSERT_TRUE(virtual_cluster_manager.ContainsVirtualCluster(virtual_cluster_id_0));
 
@@ -62,7 +62,7 @@ TEST_F(VirtualClusterManagerTest, TestContainsNodeInstance) {
 
   rpc::VirtualClusterTableData virtual_cluster_data;
   virtual_cluster_data.set_id(virtual_cluster_id_0);
-  virtual_cluster_data.set_mode(rpc::AllocationMode::MIXED);
+  virtual_cluster_data.set_divisible(false);
   virtual_cluster_data.set_revision(100);
   absl::flat_hash_set<NodeID> node_ids;
   for (size_t i = 0; i < 100; ++i) {

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -111,8 +111,9 @@ Status RayletClient::AnnounceWorkerPortForWorker(int port) {
   return conn_->WriteMessage(MessageType::AnnounceWorkerPort, &fbb);
 }
 
-Status RayletClient::AnnounceWorkerPortForDriver(
-    int port, const std::string &entrypoint, const std::string &virtual_cluster_id) {
+Status RayletClient::AnnounceWorkerPortForDriver(int port,
+                                                 const std::string &entrypoint,
+                                                 const std::string &virtual_cluster_id) {
   flatbuffers::FlatBufferBuilder fbb;
   auto message = protocol::CreateAnnounceWorkerPort(
       fbb, port, fbb.CreateString(entrypoint), fbb.CreateString(virtual_cluster_id));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR is 21/N implementation of the VirtualCluster (see issue https://github.com/antgroup/ant-ray/issues/409) . refactor mixed/exclusive cluster to indivisible/divisible cluster.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
