### PR TITLE
[22/N][VirtualCluster] Implement Resubscribe for virtual cluster info…

### DIFF
--- a/src/ray/gcs/gcs_client/accessor.ant.cc
+++ b/src/ray/gcs/gcs_client/accessor.ant.cc
@@ -94,5 +94,20 @@ Status VirtualClusterInfoAccessor::AsyncSubscribeAll(
       [this, done](const Status &status) { fetch_all_data_operation_(done); });
 }
 
+void VirtualClusterInfoAccessor::AsyncResubscribe() {
+  RAY_LOG(DEBUG) << "Reestablishing subscription for virtual cluster info.";
+  auto fetch_all_done = [](const Status &status) {
+    RAY_LOG(INFO)
+        << "Finished fetching all virtual cluster information from gcs server after gcs "
+           "server or pub-sub server is restarted.";
+  };
+
+  if (subscribe_operation_ != nullptr) {
+    RAY_CHECK_OK(subscribe_operation_([this, fetch_all_done](const Status &status) {
+      fetch_all_data_operation_(fetch_all_done);
+    }));
+  }
+}
+
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -1029,6 +1029,13 @@ class VirtualClusterInfoAccessor {
       const SubscribeCallback<VirtualClusterID, rpc::VirtualClusterTableData> &subscribe,
       const StatusCallback &done);
 
+  /// Reestablish subscription.
+  /// This should be called when GCS server restarts from a failure.
+  /// PubSub server restart will cause GCS server restart. In this case, we need to
+  /// resubscribe from PubSub server, otherwise we only need to fetch data from GCS
+  /// server.
+  virtual void AsyncResubscribe();
+
  private:
   /// Save the fetch data operation in this function, so we can call it again when GCS
   /// server restarts from a failure.

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -119,6 +119,7 @@ Status GcsClient::Connect(instrumented_io_context &io_service, int64_t timeout_m
     node_accessor_->AsyncResubscribe();
     node_resource_accessor_->AsyncResubscribe();
     worker_accessor_->AsyncResubscribe();
+    virtual_cluster_accessor_->AsyncResubscribe();
   };
 
   rpc::Address gcs_address;


### PR DESCRIPTION
… accessor

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
This PR is 5/N implementation of the VirtualCluster (see issue https://github.com/antgroup/ant-ray/issues/409) . This mplement Resubscribe for virtual cluster info accessor.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
