### PR TITLE
[23/N][VirtualCluster]add node_instances_map to speed up the lookup of node instances

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
@@ -243,9 +243,12 @@ class VirtualCluster {
   ReplicaInstances visible_node_instances_;
   /// Replica sets to express the visible node instances.
   ReplicaSets replica_sets_;
-  // Version number of the last modification to the cluster.
+  /// Version number of the last modification to the cluster.
   uint64_t revision_{0};
-
+  /// The mapping from node instance id to `NodeInstance` instance.
+  /// `node_instances_map_` and `visible_node_instances_` are two views of the same node
+  /// instance.
+  absl::flat_hash_map<std::string, std::shared_ptr<NodeInstance>> node_instances_map_;
   const ClusterResourceManager &cluster_resource_manager_;
 };
 


### PR DESCRIPTION
…f node instances

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR is 23/N implementation of the VirtualCluster (see issue https://github.com/antgroup/ant-ray/issues/409) . This PR adds a node_instances_map to speed up the lookup of node instances.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
