### PR TITLE
[25/N][VirtualCluster] Introduce undevided node instances concept

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
@@ -63,7 +63,7 @@ struct NodeInstance {
   bool is_dead_ = false;
 };
 
-static const std::string kEmptyJobClusterId = "NIL";
+static const std::string kUndividedClusterId = "NIL";
 
 /// <template_id, _>
 ///               |
@@ -116,7 +116,7 @@ ReplicaInstances toReplicaInstances(const T &node_instances) {
     auto inst = std::make_shared<NodeInstance>(id);
     inst->set_hostname(node_instance.hostname());
     inst->set_template_id(node_instance.template_id());
-    result[node_instance.template_id()][kEmptyJobClusterId].emplace(id, std::move(inst));
+    result[node_instance.template_id()][kUndividedClusterId].emplace(id, std::move(inst));
   }
   return result;
 }
@@ -161,7 +161,7 @@ class VirtualCluster {
   void UpdateNodeInstances(ReplicaInstances replica_instances_to_add,
                            ReplicaInstances replica_instances_to_remove);
 
-  /// Lookup node instances from queue of kEmptyJobClusterId in `visible_node_instances_`
+  /// Lookup undivided node instances from `visible_node_instances_`
   /// based on the desired final replica sets and node_instance_filter.
   ///
   /// \param replica_sets The demand final replica sets.
@@ -169,9 +169,9 @@ class VirtualCluster {
   /// node instances.
   /// \param node_instance_filter The filter to check if the node instance is desired.
   /// \return True if the lookup is successful, otherwise return an error.
-  bool LookupNodeInstances(const ReplicaSets &replica_sets,
-                           ReplicaInstances &replica_instances,
-                           NodeInstanceFilter node_instance_filter) const;
+  bool LookupUndividedNodeInstances(const ReplicaSets &replica_sets,
+                                    ReplicaInstances &replica_instances,
+                                    NodeInstanceFilter node_instance_filter) const;
 
   /// Mark the node instance as dead.
   ///
@@ -211,19 +211,26 @@ class VirtualCluster {
   ///
   /// \param node_instance The node instance to be checked.
   /// \return True if the node instance is idle, false otherwise.
-  virtual bool IsIdleNodeInstance(const gcs::NodeInstance &node_instance) const = 0;
+  virtual bool IsUndividedNodeInstanceIdle(
+      const gcs::NodeInstance &node_instance) const = 0;
 
   /// Replenish the node instances of the virtual cluster.
   ///
   /// \param callback The callback to replenish the dead node instances.
   /// \return True if any dead node instances are replenished, false otherwise.
-  virtual bool ReplenishNodeInstances(const NodeInstanceReplenishCallback &callback);
+  virtual bool ReplenishNodeInstances(const NodeInstanceReplenishCallback &callback) = 0;
+
+  /// Replenish the undivided node instances of the virtual cluster.
+  ///
+  /// \param callback The callback to replenish the dead node instances.
+  /// \return True if any dead node instances are replenished, false otherwise.
+  bool ReplenishUndividedNodeInstances(const NodeInstanceReplenishCallback &callback);
 
   /// Replenish a node instance.
   ///
   /// \param node_instance_to_replenish The node instance to replenish.
   /// \return True if the node instances is replenished, false otherwise.
-  std::shared_ptr<NodeInstance> ReplenishNodeInstance(
+  std::shared_ptr<NodeInstance> ReplenishUndividedNodeInstance(
       std::shared_ptr<NodeInstance> node_instance_to_replenish);
 
  protected:
@@ -319,7 +326,7 @@ class DivisibleCluster : public VirtualCluster {
   ///
   /// \param node_instance The node instance to be checked.
   /// \return True if the node instance is idle, false otherwise.
-  bool IsIdleNodeInstance(const gcs::NodeInstance &node_instance) const override;
+  bool IsUndividedNodeInstanceIdle(const gcs::NodeInstance &node_instance) const override;
 
   /// Replenish the node instances of the virtual cluster.
   ///
@@ -362,7 +369,13 @@ class IndivisibleCluster : public VirtualCluster {
   ///
   /// \param node_instance The node instance to be checked.
   /// \return True if the node instance is idle, false otherwise.
-  bool IsIdleNodeInstance(const gcs::NodeInstance &node_instance) const override;
+  bool IsUndividedNodeInstanceIdle(const gcs::NodeInstance &node_instance) const override;
+
+  /// Replenish the node instances of the virtual cluster.
+  ///
+  /// \param callback The callback to replenish the dead node instances.
+  /// \return True if any dead node instances are replenished, false otherwise.
+  bool ReplenishNodeInstances(const NodeInstanceReplenishCallback &callback) override;
 };
 
 class JobCluster : public IndivisibleCluster {

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.cc
@@ -63,7 +63,7 @@ void GcsVirtualClusterManager::OnJobFinished(const rpc::JobTableData &job_data) 
   }
 
   if (!virtual_cluster->Divisible()) {
-    // this should not happen, virtual cluster should be exclusive
+    // this should not happen, virtual cluster should be divisible.
     return;
   }
 

--- a/src/ray/gcs/gcs_server/test/gcs_virtual_cluster_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_virtual_cluster_manager_test.cc
@@ -242,7 +242,7 @@ TEST_F(PrimaryClusterTest, NodeAddAndRemove) {
   EXPECT_EQ(visiable_node_instances.size(), template_count);
   for (auto &[template_id, job_node_instances] : visiable_node_instances) {
     EXPECT_EQ(job_node_instances.size(), 1);
-    EXPECT_EQ(job_node_instances.begin()->first, ray::gcs::kEmptyJobClusterId);
+    EXPECT_EQ(job_node_instances.begin()->first, ray::gcs::kUndividedClusterId);
     EXPECT_EQ(job_node_instances.begin()->second.size(), node_count / template_count);
   }
 
@@ -261,7 +261,7 @@ TEST_F(PrimaryClusterTest, NodeAddAndRemove) {
   }
   for (auto &[template_id, job_node_instances] : visiable_node_instances) {
     EXPECT_EQ(job_node_instances.size(), 1);
-    EXPECT_EQ(job_node_instances.begin()->first, ray::gcs::kEmptyJobClusterId);
+    EXPECT_EQ(job_node_instances.begin()->first, ray::gcs::kUndividedClusterId);
     EXPECT_EQ(job_node_instances.begin()->second.size(), node_count / template_count);
 
     size_t alive_count = 0;
@@ -288,7 +288,7 @@ TEST_F(PrimaryClusterTest, NodeAddAndRemove) {
   EXPECT_EQ(visiable_node_instances.size(), template_count);
   for (auto &[template_id, job_node_instances] : visiable_node_instances) {
     EXPECT_EQ(job_node_instances.size(), 1);
-    EXPECT_EQ(job_node_instances.begin()->first, ray::gcs::kEmptyJobClusterId);
+    EXPECT_EQ(job_node_instances.begin()->first, ray::gcs::kUndividedClusterId);
     EXPECT_EQ(job_node_instances.begin()->second.size(), node_count / template_count);
 
     size_t alive_count = 0;
@@ -324,10 +324,11 @@ TEST_F(PrimaryClusterTest, CreateOrUpdateVirtualCluster) {
     // Check that template_id_0 has 5 nodes, template_id_1 has 10 nodes.
     EXPECT_EQ(visiable_node_instances.size(), 2);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kEmptyJobClusterId).size(), 5);
+    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kUndividedClusterId).size(),
+              5);
 
     EXPECT_EQ(visiable_node_instances.at(template_id_1).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kUndividedClusterId).size(),
               10);
 
     // Check that the revision changed.
@@ -341,11 +342,11 @@ TEST_F(PrimaryClusterTest, CreateOrUpdateVirtualCluster) {
     // template_count - 10 nodes.
     EXPECT_EQ(visiable_node_instances.size(), template_count);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kUndividedClusterId).size(),
               node_count_per_template - 5);
 
     EXPECT_EQ(visiable_node_instances.at(template_id_1).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kUndividedClusterId).size(),
               node_count_per_template - 10);
 
     // Check that the revision unchanged.
@@ -368,11 +369,11 @@ TEST_F(PrimaryClusterTest, CreateOrUpdateVirtualCluster) {
     // Check that template_id_0 has 5 nodes, template_id_1 has 10 nodes.
     EXPECT_EQ(visiable_node_instances.size(), 2);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kUndividedClusterId).size(),
               node_count_per_template - 5);
 
     EXPECT_EQ(visiable_node_instances.at(template_id_1).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kUndividedClusterId).size(),
               node_count_per_template - 10);
 
     // Check that the revision changed.
@@ -453,29 +454,30 @@ TEST_F(PrimaryClusterTest, CreateJobCluster) {
     // Check that template_id_0 has 5 nodes, template_id_1 has 10 nodes.
     EXPECT_EQ(visiable_node_instances.size(), 2);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kEmptyJobClusterId).size(), 5);
+    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kUndividedClusterId).size(),
+              5);
 
     EXPECT_EQ(visiable_node_instances.at(template_id_1).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kUndividedClusterId).size(),
               10);
   }
 
   {
     // Check the primary cluster visible node instances.
     const auto &visiable_node_instances = primary_cluster->GetVisibleNodeInstances();
-    // Check that job_cluster_id_0 in template_id_0 has 5 nodes, kEmptyJobClusterId in
+    // Check that job_cluster_id_0 in template_id_0 has 5 nodes, kUndividedClusterId in
     // template_id_0 has template_count - 5 nodes.
     EXPECT_EQ(visiable_node_instances.size(), template_count);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).size(), 2);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).at(job_cluster_id_0).size(), 5);
-    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kUndividedClusterId).size(),
               node_count_per_template - 5);
 
-    // Check that job_cluster_id_0 in template_id_1 has 10 nodes, kEmptyJobClusterId in
+    // Check that job_cluster_id_0 in template_id_1 has 10 nodes, kUndividedClusterId in
     // template_id_1 has template_count - 10 nodes.
     EXPECT_EQ(visiable_node_instances.at(template_id_1).size(), 2);
     EXPECT_EQ(visiable_node_instances.at(template_id_1).at(job_cluster_id_0).size(), 10);
-    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kUndividedClusterId).size(),
               node_count_per_template - 10);
   }
 
@@ -503,11 +505,11 @@ TEST_F(PrimaryClusterTest, CreateJobCluster) {
     // node_count_per_template - 10 nodes.
     EXPECT_EQ(visiable_node_instances.size(), 2);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kUndividedClusterId).size(),
               node_count_per_template - 5);
 
     EXPECT_EQ(visiable_node_instances.at(template_id_1).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kUndividedClusterId).size(),
               node_count_per_template - 10);
   }
 
@@ -515,23 +517,23 @@ TEST_F(PrimaryClusterTest, CreateJobCluster) {
     // Check the primary cluster visible node instances.
     const auto &visiable_node_instances = primary_cluster->GetVisibleNodeInstances();
     // Check that job_cluster_id_0 in template_id_0 has 5 nodes,
-    // job_cluster_id_1 in template_id_0 has template_count - 5 nodes, kEmptyJobClusterId
+    // job_cluster_id_1 in template_id_0 has template_count - 5 nodes, kUndividedClusterId
     // does not exist in template_id_0.
     EXPECT_EQ(visiable_node_instances.size(), template_count);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).size(), 2);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).at(job_cluster_id_0).size(), 5);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).at(job_cluster_id_1).size(),
               node_count_per_template - 5);
-    ASSERT_FALSE(visiable_node_instances.at(template_id_0).contains(kEmptyJobClusterId));
+    ASSERT_FALSE(visiable_node_instances.at(template_id_0).contains(kUndividedClusterId));
 
     // Check that job_cluster_id_0 in template_id_1 has 10 nodes,
-    // job_cluster_id_1 in template_id_0 has template_count - 10 nodes, kEmptyJobClusterId
-    // does not exist in template_id_1.
+    // job_cluster_id_1 in template_id_0 has template_count - 10 nodes,
+    // kUndividedClusterId does not exist in template_id_1.
     EXPECT_EQ(visiable_node_instances.at(template_id_1).size(), 2);
     EXPECT_EQ(visiable_node_instances.at(template_id_1).at(job_cluster_id_0).size(), 10);
     EXPECT_EQ(visiable_node_instances.at(template_id_1).at(job_cluster_id_1).size(),
               node_count_per_template - 10);
-    ASSERT_FALSE(visiable_node_instances.at(template_id_0).contains(kEmptyJobClusterId));
+    ASSERT_FALSE(visiable_node_instances.at(template_id_0).contains(kUndividedClusterId));
   }
 }
 
@@ -566,29 +568,30 @@ TEST_F(PrimaryClusterTest, RemoveJobCluster) {
     // Check that template_id_0 has 5 nodes, template_id_1 has 10 nodes.
     EXPECT_EQ(visiable_node_instances.size(), 2);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kEmptyJobClusterId).size(), 5);
+    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kUndividedClusterId).size(),
+              5);
 
     EXPECT_EQ(visiable_node_instances.at(template_id_1).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kUndividedClusterId).size(),
               10);
   }
 
   {
     // Check the primary cluster visible node instances.
     const auto &visiable_node_instances = primary_cluster->GetVisibleNodeInstances();
-    // Check that job_cluster_id_0 in template_id_0 has 5 nodes, kEmptyJobClusterId in
+    // Check that job_cluster_id_0 in template_id_0 has 5 nodes, kUndividedClusterId in
     // template_id_0 has template_count - 5 nodes.
     EXPECT_EQ(visiable_node_instances.size(), template_count);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).size(), 2);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).at(job_cluster_id_0).size(), 5);
-    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kUndividedClusterId).size(),
               node_count_per_template - 5);
 
-    // Check that job_cluster_id_0 in template_id_1 has 10 nodes, kEmptyJobClusterId in
+    // Check that job_cluster_id_0 in template_id_1 has 10 nodes, kUndividedClusterId in
     // template_id_1 has template_count - 10 nodes.
     EXPECT_EQ(visiable_node_instances.at(template_id_1).size(), 2);
     EXPECT_EQ(visiable_node_instances.at(template_id_1).at(job_cluster_id_0).size(), 10);
-    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kUndividedClusterId).size(),
               node_count_per_template - 10);
   }
 
@@ -611,12 +614,12 @@ TEST_F(PrimaryClusterTest, RemoveJobCluster) {
     // Check that template_id_0 has node_count_per_template nodes.
     EXPECT_EQ(visiable_node_instances.size(), template_count);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kUndividedClusterId).size(),
               node_count_per_template);
 
     // Check that template_id_1 has node_count_per_template nodes.
     EXPECT_EQ(visiable_node_instances.at(template_id_1).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kUndividedClusterId).size(),
               node_count_per_template);
   }
 
@@ -656,10 +659,11 @@ TEST_F(PrimaryClusterTest, RemoveVirtualCluster) {
     // Check that template_id_0 has 5 nodes, template_id_1 has 10 nodes.
     EXPECT_EQ(visiable_node_instances.size(), 2);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kEmptyJobClusterId).size(), 5);
+    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kUndividedClusterId).size(),
+              5);
 
     EXPECT_EQ(visiable_node_instances.at(template_id_1).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kUndividedClusterId).size(),
               10);
 
     // Check that the revision changed.
@@ -673,11 +677,11 @@ TEST_F(PrimaryClusterTest, RemoveVirtualCluster) {
     // template_count - 10 nodes.
     EXPECT_EQ(visiable_node_instances.size(), template_count);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kUndividedClusterId).size(),
               node_count_per_template - 5);
 
     EXPECT_EQ(visiable_node_instances.at(template_id_1).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kUndividedClusterId).size(),
               node_count_per_template - 10);
 
     // Check that the revision unchanged.
@@ -703,12 +707,12 @@ TEST_F(PrimaryClusterTest, RemoveVirtualCluster) {
     // Check that template_id_0 has node_count_per_template nodes.
     EXPECT_EQ(visiable_node_instances.size(), template_count);
     EXPECT_EQ(visiable_node_instances.at(template_id_0).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_0).at(kUndividedClusterId).size(),
               node_count_per_template);
 
     // Check that template_id_1 has node_count_per_template nodes.
     EXPECT_EQ(visiable_node_instances.at(template_id_1).size(), 1);
-    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kEmptyJobClusterId).size(),
+    EXPECT_EQ(visiable_node_instances.at(template_id_1).at(kUndividedClusterId).size(),
               node_count_per_template);
   }
 
@@ -870,10 +874,10 @@ class FailoverTest : public PrimaryClusterTest {
     if (auto virtual_cluster = primary_cluster_->GetVirtualCluster(virtual_cluster_id)) {
       ReplicaSets replica_sets{{template_id, 1}};
       ReplicaInstances replica_instances;
-      if (virtual_cluster->LookupNodeInstances(
+      if (virtual_cluster->LookupUndividedNodeInstances(
               replica_sets, replica_instances, nullptr)) {
         return NodeID::FromHex(
-            replica_instances.at(template_id).at(kEmptyJobClusterId).begin()->first);
+            replica_instances.at(template_id).at(kUndividedClusterId).begin()->first);
       }
     }
     return NodeID::Nil();
@@ -997,7 +1001,7 @@ TEST_F(FailoverTest, FailoverWithDeadNodes) {
     // Assume that the dead nodes in job cluster 1 is replaced by a new alive one from
     // primary cluster.
     auto node_instance_replenish_callback = [primary_cluster](auto node_instance) {
-      return primary_cluster->ReplenishNodeInstance(std::move(node_instance));
+      return primary_cluster->ReplenishUndividedNodeInstance(std::move(node_instance));
     };
     ASSERT_TRUE(
         virtual_cluster_1->ReplenishNodeInstances(node_instance_replenish_callback));
@@ -1070,7 +1074,7 @@ TEST_F(FailoverTest, OnlyFlushJobClusters) {
     // Assume that the dead nodes in job cluster 1 is replaced by a new alive one from
     // primary cluster.
     auto node_instance_replenish_callback = [primary_cluster](auto node_instance) {
-      return primary_cluster->ReplenishNodeInstance(std::move(node_instance));
+      return primary_cluster->ReplenishUndividedNodeInstance(std::move(node_instance));
     };
     ASSERT_TRUE(
         virtual_cluster_1->ReplenishNodeInstances(node_instance_replenish_callback));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is 23/N implementation of the VirtualCluster (see issue https://github.com/antgroup/ant-ray/issues/409) . This PR refactor `LookupNodeInstances`, `ReplenishNodeInstances` and `IsIdleNodeInstance` to `LookupUndividedNodeInstances`, `ReplenishUndividedNodeInstances` and `IsUndividedNodeInstanceIdle` to make them more clear.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
