### PR TITLE
[27/N][VirtualCluster] Remove Job Cluster asynchronously

### DIFF
--- a/python/ray/dashboard/modules/job/tests/test_job_with_virtual_cluster.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_with_virtual_cluster.py
@@ -936,7 +936,7 @@ ray.get(a.run.remote())
         runtime_env = upload_working_dir_if_needed(runtime_env, tmp_dir, logger=logger)
         runtime_env = RuntimeEnv(**runtime_env).to_dict()
 
-        def _successful_submit():
+        def _successful_submit(head_client, runtime_env, virtual_cluster_id):
             job_id = head_client.submit_job(
                 entrypoint="python test_script.py",
                 entrypoint_memory=1,
@@ -949,6 +949,8 @@ ray.get(a.run.remote())
                 assert head_client.get_job_status(job_id) == JobStatus.SUCCEEDED
                 return True
 
+            assert head_client.get_job_status(job_id) != JobStatus.FAILED
+
             wait_for_condition(
                 partial(
                     _check_job_succeeded,
@@ -957,8 +959,9 @@ ray.get(a.run.remote())
                 ),
                 timeout=20,
             )
+            return True
 
-        _successful_submit()
+        _successful_submit(head_client, runtime_env, virtual_cluster_id)
 
         def _failed_submit():
             job_id = head_client.submit_job(
@@ -1012,7 +1015,11 @@ ray.get(a.run.remote())
         actor = ray.get_actor(name=actor_name, namespace="test")
         ray.kill(actor)
 
-        _successful_submit()
+        wait_for_condition(
+            partial(_successful_submit, head_client, runtime_env, virtual_cluster_id),
+            timeout=50,
+            retry_interval_ms=5000,
+        )
 
         _remove_pg()
 
@@ -1035,10 +1042,22 @@ ray.util.remove_placement_group(pg)
             )
             runtime_env = RuntimeEnv(**runtime_env).to_dict()
 
-            _successful_submit()
+            wait_for_condition(
+                partial(
+                    _successful_submit, head_client, runtime_env, virtual_cluster_id
+                ),
+                timeout=50,
+                retry_interval_ms=5000,
+            )
             # Test that the job submission is successful if detached is
             # early killed in job.
-            _successful_submit()
+            wait_for_condition(
+                partial(
+                    _successful_submit, head_client, runtime_env, virtual_cluster_id
+                ),
+                timeout=50,
+                retry_interval_ms=5000,
+            )
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/job/tests/test_job_with_virtual_cluster.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_with_virtual_cluster.py
@@ -880,7 +880,7 @@ async def test_list_cluster_resources(job_sdk_client):
     "job_sdk_client",
     [
         {
-            "ntemplates": 1,
+            "ntemplates": 2,
         },
     ],
     indirect=True,
@@ -895,6 +895,13 @@ async def test_detached_job_cluster(job_sdk_client):
         {TEMPLATE_ID_PREFIX + str(0): 2},
         True,
     )
+    await create_virtual_cluster(
+        gcs_address,
+        virtual_cluster_id + "_indivisible",
+        {TEMPLATE_ID_PREFIX + str(1): 2},
+        True,
+    )
+
     actor_name = "test_actor"
     pg_name = "test_pg"
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/src/ray/common/ray_config_def.ant.h
+++ b/src/ray/common/ray_config_def.ant.h
@@ -22,4 +22,4 @@
 RAY_CONFIG(uint64_t, node_instances_replenish_interval_ms, 30000)
 
 /// The interval to check and delete expired job clusters.
-RAY_CONFIG(uint64_t, gc_expired_job_clusters_interval_ms, 30000)
+RAY_CONFIG(uint64_t, expired_job_clusters_gc_interval_ms, 30000)

--- a/src/ray/common/ray_config_def.ant.h
+++ b/src/ray/common/ray_config_def.ant.h
@@ -20,3 +20,6 @@
 
 /// The interval to replenish node instances of all the virtual clusters.
 RAY_CONFIG(uint64_t, node_instances_replenish_interval_ms, 30000)
+
+/// The interval to check and delete expired job clusters.
+RAY_CONFIG(uint64_t, gc_expired_job_clusters_interval_ms, 30000)

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
@@ -400,17 +400,17 @@ class JobCluster : public IndivisibleCluster {
  public:
   using IndivisibleCluster::IndivisibleCluster;
 
-  /// Set Job as Finished
-  void SetFinished() { finished = true; }
+  /// Set Job as dead
+  void SetJobDead() { job_dead = true; }
 
-  /// Check if job is finished
+  /// Check if job is dead
   ///
-  /// \return True if the job is finished, false otherwise.
-  bool IsFinished() const { return finished; }
+  /// \return True if the job is dead, false otherwise.
+  bool IsJobDead() const { return job_dead; }
 
  private:
-  // If the job is finished
-  bool finished = false;
+  // If the job is dead
+  bool job_dead = false;
 };
 
 class PrimaryCluster : public DivisibleCluster,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR is 27/N implementation of the VirtualCluster (see issue https://github.com/antgroup/ant-ray/issues/409) . Remove Job Cluster asynchronously
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
