### PR TITLE
[28/N][VirtualCluster] Fix compile and lint error

### DIFF
--- a/python/ray/dashboard/modules/virtual_cluster/tests/test_virtual_cluster.py
+++ b/python/ray/dashboard/modules/virtual_cluster/tests/test_virtual_cluster.py
@@ -447,3 +447,7 @@ def test_get_virtual_clusters(disable_aiohttp_cache, ray_start_cluster_head):
             return False
 
     wait_for_condition(_get_virtual_clusters, timeout=10)
+
+
+if __name__ == "__main__":
+    pass

--- a/src/ray/gcs/gcs_server/test/gcs_virtual_cluster_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_virtual_cluster_manager_test.cc
@@ -1005,7 +1005,7 @@ TEST_F(FailoverTest, FailoverWithDeadNodes) {
     };
     ASSERT_TRUE(
         virtual_cluster_1->ReplenishNodeInstances(node_instance_replenish_callback));
-    async_data_flusher_(virtual_cluster_1->ToProto(), nullptr);
+    ASSERT_TRUE(async_data_flusher_(virtual_cluster_1->ToProto(), nullptr).ok());
 
     // Mock a gcs_init_data.
     instrumented_io_context io_service;

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -939,7 +939,8 @@ service VirtualClusterInfoGcsService {
   rpc CreateOrUpdateVirtualCluster(CreateOrUpdateVirtualClusterRequest)
       returns (CreateOrUpdateVirtualClusterReply);
   // Remove a virtual cluster.
-  rpc RemoveVirtualCluster(RemoveVirtualClusterRequest) returns (RemoveVirtualClusterReply);
+  rpc RemoveVirtualCluster(RemoveVirtualClusterRequest)
+      returns (RemoveVirtualClusterReply);
   // Get virtual clusters.
   rpc GetVirtualClusters(GetVirtualClustersRequest) returns (GetVirtualClustersReply);
   // Create job cluster.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR is 28/N implementation of the VirtualCluster (see issue https://github.com/antgroup/ant-ray/issues/409) . This PR just fix compile and lint error.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
