### PR TITLE
[29/N][VirtualCluster]Add virtual cluster to job submit cli command

### DIFF
--- a/python/ray/dashboard/modules/job/cli.py
+++ b/python/ray/dashboard/modules/job/cli.py
@@ -134,6 +134,20 @@ def job_cli_group():
     ),
 )
 @click.option(
+    "--virtual-cluster-id",
+    type=str,
+    default=None,
+    required=False,
+    help=("Virtual Cluster ID to specify for the job. "),
+)
+@click.option(
+    "--replica-sets",
+    type=str,
+    default=None,
+    required=False,
+    help=("Replica Sets required by the job. "),
+)
+@click.option(
     "--runtime-env",
     type=str,
     default=None,
@@ -210,6 +224,8 @@ def submit(
     address: Optional[str],
     job_id: Optional[str],
     submission_id: Optional[str],
+    virtual_cluster_id: Optional[str],
+    replica_sets: Optional[str],
     runtime_env: Optional[str],
     runtime_env_json: Optional[str],
     metadata_json: Optional[str],
@@ -252,6 +268,8 @@ def submit(
             address=address,
             job_id=submission_id,
             submission_id=submission_id,
+            virtual_cluster_id=virtual_cluster_id,
+            replica_sets=replica_sets,
             runtime_env=runtime_env,
             runtime_env_json=runtime_env_json,
             metadata_json=metadata_json,
@@ -273,9 +291,13 @@ def submit(
         runtime_env_json=runtime_env_json,
         working_dir=working_dir,
     )
+    if replica_sets is not None:
+        replica_sets = json.loads(replica_sets)
     job_id = client.submit_job(
         entrypoint=list2cmdline(entrypoint),
         submission_id=submission_id,
+        virtual_cluster_id=virtual_cluster_id,
+        replica_sets=replica_sets,
         runtime_env=final_runtime_env,
         metadata=metadata_json,
         entrypoint_num_cpus=entrypoint_num_cpus,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR is 29/N implementation of the VirtualCluster (see issue https://github.com/antgroup/ant-ray/issues/409) . This pr adds virtual cluster and replica sets options to job submit cli
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
