### PR TITLE
[VirtualCluster] Fix error logs for detached actor/pg listeners

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.cc
@@ -455,6 +455,9 @@ Status GcsVirtualClusterManager::FlushAndPublish(
 
 void GcsVirtualClusterManager::OnDetachedActorRegistration(
     const std::string &virtual_cluster_id, const ActorID &actor_id) {
+  if (virtual_cluster_id.empty()) {
+    return;
+  }
   auto virtual_cluster = GetVirtualCluster(virtual_cluster_id);
   if (virtual_cluster == nullptr) {
     RAY_LOG(ERROR) << "Failed to process the registration of detached actor " << actor_id
@@ -471,6 +474,9 @@ void GcsVirtualClusterManager::OnDetachedActorRegistration(
 
 void GcsVirtualClusterManager::OnDetachedActorDestroy(
     const std::string &virtual_cluster_id, const ActorID &actor_id) {
+  if (virtual_cluster_id.empty()) {
+    return;
+  }
   auto virtual_cluster = GetVirtualCluster(virtual_cluster_id);
   if (virtual_cluster == nullptr) {
     RAY_LOG(ERROR) << "Failed to process the destroy of detached actor " << actor_id
@@ -498,6 +504,9 @@ void GcsVirtualClusterManager::OnDetachedActorDestroy(
 
 void GcsVirtualClusterManager::OnDetachedPlacementGroupRegistration(
     const std::string &virtual_cluster_id, const PlacementGroupID &placement_group_id) {
+  if (virtual_cluster_id.empty()) {
+    return;
+  }
   auto virtual_cluster = GetVirtualCluster(virtual_cluster_id);
   if (virtual_cluster == nullptr) {
     RAY_LOG(ERROR) << "Failed to process the registration of detached placement group "
@@ -514,6 +523,9 @@ void GcsVirtualClusterManager::OnDetachedPlacementGroupRegistration(
 
 void GcsVirtualClusterManager::OnDetachedPlacementGroupDestroy(
     const std::string &virtual_cluster_id, const PlacementGroupID &placement_group_id) {
+  if (virtual_cluster_id.empty()) {
+    return;
+  }
   auto virtual_cluster = GetVirtualCluster(virtual_cluster_id);
   if (virtual_cluster == nullptr) {
     RAY_LOG(ERROR) << "Failed to process the destroy of detached placement group "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR is fix of the VirtualCluster (see issue https://github.com/antgroup/ant-ray/issues/409) . Fix error logs for listeners

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
