### PR TITLE
[VirtualCluster] Check virtual cluster name duplication when creating…

### DIFF
--- a/python/ray/dashboard/modules/virtual_cluster/cli.py
+++ b/python/ray/dashboard/modules/virtual_cluster/cli.py
@@ -11,6 +11,7 @@ from ray.autoscaler._private.cli_logger import add_click_logging_options, cli_lo
 from ray.core.generated import gcs_service_pb2_grpc
 from ray.core.generated.gcs_service_pb2 import (
     CreateOrUpdateVirtualClusterRequest,
+    GetVirtualClustersRequest,
     RemoveVirtualClusterRequest,
 )
 
@@ -69,6 +70,17 @@ def create(
 ):
     """Create a new virtual cluster."""
     stub = _get_virtual_cluster_stub(address)
+    reply = stub.GetVirtualClusters(GetVirtualClustersRequest(virtual_cluster_id=id))
+    if reply.status.code != 0:
+        cli_logger.error(
+            f"Failed to create virtual cluster '{id}': {reply.status.message}"
+        )
+        sys.exit(1)
+
+    if len(reply.virtual_cluster_data_list) > 0:
+        cli_logger.error(f"Failed to create virtual cluster '{id}': already exists")
+        sys.exit(1)
+
     if replica_sets is not None:
         replica_sets = json.loads(replica_sets)
 


### PR DESCRIPTION
… vclusters

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR is a Fix of the VirtualCluster (see issue https://github.com/antgroup/ant-ray/issues/409) . It Check virtual cluster name duplication when creating vclusters

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
