### PR TITLE
[CI] use self-hostd longrun runner

### DIFF
--- a/.github/workflows/ray-ci.yml
+++ b/.github/workflows/ray-ci.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   start-ecs-runner:
     name: Start ECS Runner
-    runs-on: ubuntu-latest
+    runs-on: longrun # this is only used to trigger ecs runner
     environment: aliyun
     concurrency:
       group: ${{ github.workflow }}
@@ -27,18 +27,10 @@ jobs:
       leased_instance_id: ${{ steps.lease_instance.outputs.instance_id }}
       leased_disk_id: ${{ steps.lease_instance.outputs.disk_id }}
     steps:
-      - name: Configure Aliyun CLI
-        run: |
-          wget https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz
-          tar -xvf aliyun-cli-linux-latest-amd64.tgz
-          ./aliyun configure set --profile default \
-            --access-key-id ${{ secrets.ALIYUN_ACCESS_KEY }} \
-            --access-key-secret ${{ secrets.ALIYUN_ACCESS_SECRET }} \
-            --region us-west-1
-
       - name: Lease and Start Instance
         id: lease_instance
         run: |
+          cd ~/actions-runner
           # Parse instance:disk pairs
           IFS=',' read -ra INSTANCE_PAIRS <<< "${{ secrets.ALIYUN_ECS_INSTANCE_IDS }}"
           
@@ -548,17 +540,11 @@ jobs:
       - build-base-images
       - core-tests
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: longrun
     steps:
       - name: Configure Aliyun CLI
         run: |
-          wget https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz
-          tar -xvf aliyun-cli-linux-latest-amd64.tgz
-          ./aliyun configure set --profile default \
-            --access-key-id ${{ secrets.ALIYUN_ACCESS_KEY }} \
-            --access-key-secret ${{ secrets.ALIYUN_ACCESS_SECRET }} \
-            --region us-west-1
-          # Add retry logic for StopInstance
+          cd ~/actions-runner
           max_attempts=3
           for i in $(seq 1 $max_attempts); do
             if ./aliyun ecs StopInstance --InstanceId ${{ needs.start-ecs-runner.outputs.leased_instance_id }} --ForceStop true --region us-west-1; then


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

use a long running runner to trigger ecs instead of github's ubuntu runners

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
