### PR TITLE
[Autoscaler v2] Autoscaler submits scale request to kuberay operator

### DIFF
--- a/python/ray/_version.py
+++ b/python/ray/_version.py
@@ -1,6 +1,6 @@
 # Replaced with the current commit when building the wheels.
 commit = "{{RAY_COMMIT_SHA}}"
-version = "3.0.0.dev0"
+version = "3.0.0.dev1"
 
 if __name__ == "__main__":
     print("%s %s" % (version, commit))

--- a/python/ray/_version.py
+++ b/python/ray/_version.py
@@ -1,6 +1,6 @@
 # Replaced with the current commit when building the wheels.
 commit = "{{RAY_COMMIT_SHA}}"
-version = "3.0.0.dev1"
+version = "2.44.1.post0"
 
 if __name__ == "__main__":
     print("%s %s" % (version, commit))

--- a/python/ray/_version.py
+++ b/python/ray/_version.py
@@ -1,6 +1,6 @@
 # Replaced with the current commit when building the wheels.
 commit = "{{RAY_COMMIT_SHA}}"
-version = "2.44.1.post0"
+version = "3.0.0.dev0"
 
 if __name__ == "__main__":
     print("%s %s" % (version, commit))

--- a/python/ray/autoscaler/_private/constants.py
+++ b/python/ray/autoscaler/_private/constants.py
@@ -140,3 +140,6 @@ DISABLE_NODE_UPDATERS_KEY = "disable_node_updaters"
 DISABLE_LAUNCH_CONFIG_CHECK_KEY = "disable_launch_config_check"
 FOREGROUND_NODE_LAUNCH_KEY = "foreground_node_launch"
 WORKER_LIVENESS_CHECK_KEY = "worker_liveness_check"
+
+KUBERAY_OPERATOR_DEFAULT_ACCESS_KEY = "KubeRayOperator"
+KUBERAY_OPERATOR_DEFAULT_ACCESS_SECRET = "S3ViZVJheU9wZXJhdG9y"

--- a/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
@@ -68,6 +68,7 @@ class KubeRayProvider(ICloudInstanceProvider):
             kuberay_http_api_enabled = os.getenv("KUBERAY_HTTP_API_ENABLED", "0") == "1"
             kuberay_operator_address = os.getenv("KUBERAY_OPERATOR_ADDRESS")
             if kuberay_http_api_enabled and kuberay_operator_address is not None:
+                logger.info("Autoscaler is using KubeRayHttpApiClient.")
                 self._k8s_api_client = KubeRayHttpApiClient(
                     namespace=self._namespace,
                     kuberay_operator_address=kuberay_operator_address,

--- a/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import os
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -17,6 +18,7 @@ from ray.autoscaler._private.kuberay.node_provider import (
     RAY_HEAD_POD_NAME,
     IKubernetesHttpApiClient,
     KubernetesHttpApiClient,
+    KubeRayHttpApiClient,
     _worker_group_index,
     _worker_group_max_replicas,
     _worker_group_replicas,
@@ -62,9 +64,19 @@ class KubeRayProvider(ICloudInstanceProvider):
         self._cluster_name = cluster_name
         self._namespace = provider_config["namespace"]
 
-        self._k8s_api_client = k8s_api_client or KubernetesHttpApiClient(
-            namespace=self._namespace
-        )
+        if k8s_api_client is None:
+            kuberay_operator_address = os.getenv("KUBERAY_OPERATOR_ADDRESS")
+            if kuberay_operator_address is not None:
+                self._k8s_api_client = KubeRayHttpApiClient(
+                    namespace=self._namespace,
+                    kuberay_operator_address=kuberay_operator_address,
+                )
+            else:
+                self._k8s_api_client = KubernetesHttpApiClient(
+                    namespace=self._namespace
+                )
+        else:
+            self._k8s_api_client = k8s_api_client
 
         # Below are states that are cached locally.
         self._requests = set()

--- a/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
@@ -65,8 +65,9 @@ class KubeRayProvider(ICloudInstanceProvider):
         self._namespace = provider_config["namespace"]
 
         if k8s_api_client is None:
+            kuberay_http_api_enabled = os.getenv("KUBERAY_HTTP_API_ENABLED", "0") == "1"
             kuberay_operator_address = os.getenv("KUBERAY_OPERATOR_ADDRESS")
-            if kuberay_operator_address is not None:
+            if kuberay_http_api_enabled and kuberay_operator_address is not None:
                 self._k8s_api_client = KubeRayHttpApiClient(
                     namespace=self._namespace,
                     kuberay_operator_address=kuberay_operator_address,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For now, autoscaler depends on KubernetesHttpApiClient to submit scale request to k8s api server. However, k8s api server is generally rate limited while requiring strict authorization. So we need a new http client (`KubeRayHttpApiClient`) which directly talks to kuberay operator.

Please see #545 for detailed REST format.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#545 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
