### PR TITLE
[VirtualCluster] Remove specified nodes from a virtual cluster

### DIFF
--- a/python/ray/dashboard/modules/virtual_cluster/virtual_cluster_head.py
+++ b/python/ray/dashboard/modules/virtual_cluster/virtual_cluster_head.py
@@ -104,7 +104,7 @@ class VirtualClusterHead(dashboard_utils.DashboardHeadModule):
             )
 
     @routes.post("/virtual_clusters/remove_nodes")
-    async def shrink_virtual_cluster(self, req) -> aiohttp.web.Response:
+    async def remove_nodes_from_virtual_cluster(self, req) -> aiohttp.web.Response:
         virtual_cluster_info_json = await req.json()
         logger.info("POST /virtual_clusters/remove_nodes %s", virtual_cluster_info_json)
 

--- a/python/ray/dashboard/modules/virtual_cluster/virtual_cluster_head.py
+++ b/python/ray/dashboard/modules/virtual_cluster/virtual_cluster_head.py
@@ -7,6 +7,7 @@ import ray.dashboard.utils as dashboard_utils
 from ray.core.generated import gcs_service_pb2_grpc
 from ray.core.generated.gcs_service_pb2 import (
     CreateOrUpdateVirtualClusterRequest,
+    RemoveNodesFromVirtualClusterRequest,
     GetVirtualClustersRequest,
     RemoveVirtualClusterRequest,
 )
@@ -100,6 +101,46 @@ class VirtualClusterHead(dashboard_utils.DashboardHeadModule):
                 ),
                 virtual_cluster_id=virtual_cluster_id,
                 replica_sets_to_recommend=data.get("replicaSetsToRecommend", {}),
+            )
+
+    @routes.post("/virtual_clusters/remove_nodes")
+    async def shrink_virtual_cluster(self, req) -> aiohttp.web.Response:
+        virtual_cluster_info_json = await req.json()
+        logger.info("POST /virtual_clusters/remove_nodes %s", virtual_cluster_info_json)
+
+        virtual_cluster_info = dict(virtual_cluster_info_json)
+        virtual_cluster_id = virtual_cluster_info["virtualClusterId"]
+
+        request = RemoveNodesFromVirtualClusterRequest(
+            virtual_cluster_id=virtual_cluster_id,
+            nodes_to_remove=virtual_cluster_info.get("nodesToRemove", []),
+        )
+        reply = await (
+            self._gcs_virtual_cluster_info_stub.RemoveNodesFromVirtualCluster(request)
+        )
+        data = dashboard_utils.message_to_dict(
+            reply, always_print_fields_with_no_presence=True
+        )
+
+        if reply.status.code == 0:
+            logger.info("Virtual cluster %s successfully updated", virtual_cluster_id)
+
+            return dashboard_optional_utils.rest_response(
+                success=True,
+                message="Virtual cluster successfully updated.",
+                virtual_cluster_id=virtual_cluster_id,
+            )
+        else:
+            logger.info(
+                "Failed to remove nodes from virtual cluster %s", virtual_cluster_id
+            )
+            return dashboard_optional_utils.rest_response(
+                success=False,
+                message="Failed to remove nodes from virtual cluster {}: {}".format(
+                    virtual_cluster_id, reply.status.message
+                ),
+                virtual_cluster_id=virtual_cluster_id,
+                nodes_with_failure=data.get("nodesWithFailure", []),
             )
 
     @routes.delete("/virtual_clusters/{virtual_cluster_id}")

--- a/src/ray/common/status.cc
+++ b/src/ray/common/status.cc
@@ -106,6 +106,16 @@ Status::Status(StatusCode code,
   state_->rpc_code = rpc_code;
 }
 
+Status::Status(StatusCode code, const std::string &msg, const std::any &data) {
+  assert(code != StatusCode::OK);
+  state_ = new State;
+  state_->code = code;
+  state_->msg = msg;
+  state_->loc = SourceLocation{};
+  state_->rpc_code = -1;
+  state_->data = data;
+}
+
 void Status::CopyFrom(const State *state) {
   delete state_;
   if (state == nullptr) {

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <any>
 #include <cstring>
 #include <iosfwd>
 #include <string>
@@ -119,6 +120,7 @@ class RAY_EXPORT Status {
 
   Status(StatusCode code, const std::string &msg, int rpc_code = -1);
   Status(StatusCode code, const std::string &msg, SourceLocation loc, int rpc_code = -1);
+  Status(StatusCode code, const std::string &msg, const std::any &data);
 
   // Copy the specified status.
   Status(const Status &s);
@@ -256,8 +258,8 @@ class RAY_EXPORT Status {
     return Status(StatusCode::ChannelTimeoutError, msg);
   }
 
-  static Status UnsafeToRemove(const std::string &msg) {
-    return Status(StatusCode::UnsafeToRemove, msg);
+  static Status UnsafeToRemove(const std::string &msg, const std::any &data) {
+    return Status(StatusCode::UnsafeToRemove, msg, data);
   }
 
   static StatusCode StringToCode(const std::string &str);
@@ -335,6 +337,8 @@ class RAY_EXPORT Status {
 
   std::string message() const { return ok() ? "" : state_->msg; }
 
+  std::any data() const { return ok() ? std::any() : state_->data; }
+
   template <typename... T>
   Status &operator<<(T &&...msg) {
     absl::StrAppend(&state_->msg, std::forward<T>(msg)...);
@@ -348,6 +352,8 @@ class RAY_EXPORT Status {
     SourceLocation loc;
     // If code is RpcError, this contains the RPC error code
     int rpc_code;
+    // The supportive data that helps explaining why status is not ok.
+    std::any data;
   };
   // Use raw pointer instead of unique pointer to achieve copiable `Status`.
   //

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.cc
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.cc
@@ -152,8 +152,8 @@ void VirtualCluster::RemoveNodeInstances(ReplicaInstances replica_instances) {
   }
 }
 
-void VirtualCluster::RemoveNodeInstances(const std::vector<std::string> &nodes_to_remove,
-                                         std::vector<std::string> *nodes_with_failure) {
+Status VirtualCluster::RemoveNodeInstances(
+    const std::vector<std::string> &nodes_to_remove) {
   absl::flat_hash_set<std::string> node_set_to_remove(nodes_to_remove.begin(),
                                                       nodes_to_remove.end());
   ReplicaInstances replica_instances_to_remove;
@@ -171,12 +171,16 @@ void VirtualCluster::RemoveNodeInstances(const std::vector<std::string> &nodes_t
     }
   }
   if (!node_set_to_remove.empty()) {
-    nodes_with_failure->insert(
-        nodes_with_failure->end(), node_set_to_remove.begin(), node_set_to_remove.end());
-    return;
+    std::vector<std::string> nodes_with_failure(node_set_to_remove.begin(),
+                                                node_set_to_remove.end());
+    return Status::UnsafeToRemove(
+        "Failed to remove some of the nodes because they are not idle nor found in the "
+        "virtual cluster. These nodes with failure are shown below.",
+        std::any(nodes_with_failure));
   }
 
   RemoveNodeInstances(replica_instances_to_remove);
+  return Status::OK();
 }
 
 bool VirtualCluster::IsNodeInstanceIdle(const std::string &node_instance_id) {
@@ -896,7 +900,8 @@ Status PrimaryCluster::DetermineNodeInstanceAdditionsAndRemovals(
           "No enough nodes to remove from the virtual cluster. The replica sets that gcs "
           "can remove "
           "at most are shown below. Use it as a suggestion to "
-          "adjust your request or cluster.");
+          "adjust your request or cluster.",
+          std::any());
     }
   }
 
@@ -953,17 +958,12 @@ void PrimaryCluster::OnNodeInstanceDead(const std::string &node_instance_id,
 
 Status PrimaryCluster::RemoveNodesFromVirtualCluster(
     const rpc::RemoveNodesFromVirtualClusterRequest &request,
-    RemoveNodesFromVirtualClusterCallback callback,
-    std::vector<std::string> *nodes_with_failure) {
+    RemoveNodesFromVirtualClusterCallback callback) {
   auto logical_cluster = GetLogicalCluster(request.virtual_cluster_id());
-  logical_cluster->RemoveNodeInstances(
-      std::vector<std::string>(request.nodes_to_remove().begin(),
-                               request.nodes_to_remove().end()),
-      nodes_with_failure);
-  if (!nodes_with_failure->empty()) {
-    return Status::UnsafeToRemove(
-        "Failed to remove some of the nodes because they are not idle nor found in the "
-        "virtual cluster. These nodes with failure are shown below.");
+  auto status = logical_cluster->RemoveNodeInstances(std::vector<std::string>(
+      request.nodes_to_remove().begin(), request.nodes_to_remove().end()));
+  if (!status.ok()) {
+    return status;
   }
   return async_data_flusher_(logical_cluster->ToProto(), std::move(callback));
 }
@@ -1026,7 +1026,7 @@ Status PrimaryCluster::RemoveLogicalCluster(const std::string &logical_cluster_i
     auto message = ostr.str();
     RAY_LOG(ERROR) << message;
 
-    return Status::UnsafeToRemove(message);
+    return Status::UnsafeToRemove(message, std::any());
   }
 
   const auto &replica_instances_to_remove = logical_cluster->GetVisibleNodeInstances();

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
@@ -258,7 +258,7 @@ class VirtualCluster {
   std::shared_ptr<NodeInstance> ReplenishUndividedNodeInstance(
       std::shared_ptr<NodeInstance> node_instance_to_replenish);
 
-  void RemoveNodeInstances(const std::vector<std::string> &nodes_to_shrink,
+  void RemoveNodeInstances(const std::vector<std::string> &nodes_to_remove,
                            std::vector<std::string> *nodes_with_failure);
 
  protected:

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
@@ -99,6 +99,8 @@ using CreateOrUpdateVirtualClusterCallback = std::function<void(
 
 using RemoveVirtualClusterCallback = CreateOrUpdateVirtualClusterCallback;
 
+using RemoveNodesFromVirtualClusterCallback = CreateOrUpdateVirtualClusterCallback;
+
 using VirtualClustersDataVisitCallback =
     std::function<void(std::shared_ptr<rpc::VirtualClusterTableData>)>;
 
@@ -256,6 +258,9 @@ class VirtualCluster {
   std::shared_ptr<NodeInstance> ReplenishUndividedNodeInstance(
       std::shared_ptr<NodeInstance> node_instance_to_replenish);
 
+  void RemoveNodeInstances(const std::vector<std::string> &nodes_to_shrink,
+                           std::vector<std::string> *nodes_with_failure);
+
  protected:
   /// Insert the node instances to the cluster.
   ///
@@ -266,6 +271,8 @@ class VirtualCluster {
   ///
   /// \param replica_instances The node instances to be removed.
   void RemoveNodeInstances(ReplicaInstances replica_instances);
+
+  bool IsNodeInstanceIdle(const std::string &node_instance_id);
 
   /// The id of the virtual cluster.
   std::string id_;
@@ -476,6 +483,11 @@ class PrimaryCluster : public DivisibleCluster,
   Status CreateOrUpdateVirtualCluster(rpc::CreateOrUpdateVirtualClusterRequest request,
                                       CreateOrUpdateVirtualClusterCallback callback,
                                       ReplicaSets *replica_sets_to_recommend = nullptr);
+
+  Status RemoveNodesFromVirtualCluster(
+      const rpc::RemoveNodesFromVirtualClusterRequest &request,
+      RemoveNodesFromVirtualClusterCallback callback,
+      std::vector<std::string> *nodes_with_failure);
 
   /// Get the virtual cluster by the logical cluster id.
   ///

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
@@ -258,8 +258,7 @@ class VirtualCluster {
   std::shared_ptr<NodeInstance> ReplenishUndividedNodeInstance(
       std::shared_ptr<NodeInstance> node_instance_to_replenish);
 
-  void RemoveNodeInstances(const std::vector<std::string> &nodes_to_remove,
-                           std::vector<std::string> *nodes_with_failure);
+  Status RemoveNodeInstances(const std::vector<std::string> &nodes_to_remove);
 
  protected:
   /// Insert the node instances to the cluster.
@@ -486,8 +485,7 @@ class PrimaryCluster : public DivisibleCluster,
 
   Status RemoveNodesFromVirtualCluster(
       const rpc::RemoveNodesFromVirtualClusterRequest &request,
-      RemoveNodesFromVirtualClusterCallback callback,
-      std::vector<std::string> *nodes_with_failure);
+      RemoveNodesFromVirtualClusterCallback callback);
 
   /// Get the virtual cluster by the logical cluster id.
   ///

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.h
@@ -95,6 +95,11 @@ class GcsVirtualClusterManager : public rpc::VirtualClusterInfoHandler {
       rpc::CreateOrUpdateVirtualClusterReply *reply,
       rpc::SendReplyCallback send_reply_callback) override;
 
+  void HandleRemoveNodesFromVirtualCluster(
+      rpc::RemoveNodesFromVirtualClusterRequest request,
+      rpc::RemoveNodesFromVirtualClusterReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override;
+
   void HandleRemoveVirtualCluster(rpc::RemoveVirtualClusterRequest request,
                                   rpc::RemoveVirtualClusterReply *reply,
                                   rpc::SendReplyCallback send_reply_callback) override;
@@ -113,6 +118,8 @@ class GcsVirtualClusterManager : public rpc::VirtualClusterInfoHandler {
       rpc::SendReplyCallback send_reply_callback) override;
 
   Status VerifyRequest(const rpc::CreateOrUpdateVirtualClusterRequest &request);
+
+  Status VerifyRequest(const rpc::RemoveNodesFromVirtualClusterRequest &request);
 
   Status VerifyRequest(const rpc::RemoveVirtualClusterRequest &request);
 

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -893,6 +893,16 @@ message CreateOrUpdateVirtualClusterReply {
   map<string, int32> replica_sets_to_recommend = 4;
 }
 
+message RemoveNodesFromVirtualClusterRequest {
+  string virtual_cluster_id = 1;
+  repeated string nodes_to_remove = 2;
+}
+
+message RemoveNodesFromVirtualClusterReply {
+  GcsStatus status = 1;
+  repeated string nodes_with_failure = 2;
+}
+
 message RemoveVirtualClusterRequest {
   // ID of the virtual cluster to be removed.
   string virtual_cluster_id = 1;
@@ -978,6 +988,9 @@ service VirtualClusterInfoGcsService {
   // Create or update a virtual cluster.
   rpc CreateOrUpdateVirtualCluster(CreateOrUpdateVirtualClusterRequest)
       returns (CreateOrUpdateVirtualClusterReply);
+  // Remove specified nodes from a virtual cluster.
+  rpc RemoveNodesFromVirtualCluster(RemoveNodesFromVirtualClusterRequest)
+      returns (RemoveNodesFromVirtualClusterReply);
   // Remove a virtual cluster.
   rpc RemoveVirtualCluster(RemoveVirtualClusterRequest)
       returns (RemoveVirtualClusterReply);

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -569,6 +569,12 @@ class GcsRpcClient {
                              virtual_cluster_info_grpc_client_,
                              /*method_timeout_ms*/ -1, )
 
+  // Remove specified nodes from a virtual cluster.
+  VOID_GCS_RPC_CLIENT_METHOD(VirtualClusterInfoGcsService,
+                             RemoveNodesFromVirtualCluster,
+                             virtual_cluster_info_grpc_client_,
+                             /*method_timeout_ms*/ -1, )
+
   // Remove a virtual cluster.
   VOID_GCS_RPC_CLIENT_METHOD(VirtualClusterInfoGcsService,
                              RemoveVirtualCluster,

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -734,6 +734,11 @@ class VirtualClusterInfoGcsServiceHandler {
       CreateOrUpdateVirtualClusterReply *reply,
       SendReplyCallback send_reply_callback) = 0;
 
+  virtual void HandleRemoveNodesFromVirtualCluster(
+      RemoveNodesFromVirtualClusterRequest request,
+      RemoveNodesFromVirtualClusterReply *reply,
+      SendReplyCallback send_reply_callback) = 0;
+
   virtual void HandleRemoveVirtualCluster(RemoveVirtualClusterRequest request,
                                           RemoveVirtualClusterReply *reply,
                                           SendReplyCallback send_reply_callback) = 0;
@@ -768,6 +773,7 @@ class VirtualClusterInfoGrpcService : public GrpcService {
       std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
       const ClusterID &cluster_id) override {
     VIRTUAL_CLUSTER_SERVICE_RPC_HANDLER(CreateOrUpdateVirtualCluster);
+    VIRTUAL_CLUSTER_SERVICE_RPC_HANDLER(RemoveNodesFromVirtualCluster);
     VIRTUAL_CLUSTER_SERVICE_RPC_HANDLER(RemoveVirtualCluster);
     VIRTUAL_CLUSTER_SERVICE_RPC_HANDLER(GetVirtualClusters);
     VIRTUAL_CLUSTER_SERVICE_RPC_HANDLER(CreateJobCluster);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Sometimes, users or autoscaler need to remove specified nodes from a virtual cluster. This could happen when some nodes have been idle for certain amount of time. This PR provides such an API.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
