### PR TITLE
[Core][Runtime Env] Add independent working_dir to LD_LIBRARY_PATH

### DIFF
--- a/python/ray/_private/runtime_env/context.py
+++ b/python/ray/_private/runtime_env/context.py
@@ -113,7 +113,7 @@ class RuntimeEnvContext:
             executable = ["exec"]
 
         # try update ld_library path
-        try_update_ld_library_path(language, self.native_libraries)
+        try_update_ld_library_path(language, self.native_libraries, self.working_dir)
 
         # try update ld_preload
         try_update_ld_preload(self.preload_libraries)

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -2056,7 +2056,9 @@ def try_update_ld_preload(preload_libraries: List[str]):
     os.environ[runtime_env_constants.PRELOAD_ENV_NAME] = ld_preload_env
 
 
-def try_update_ld_library_path(language: Language, native_libraries: dict):
+def try_update_ld_library_path(
+    language: Language, native_libraries: dict, working_dir: Optional[str]
+):
     all_library_paths = ""
     if language == Language.CPP:
         all_library_paths += get_ray_native_library_dir()
@@ -2069,4 +2071,8 @@ def try_update_ld_library_path(language: Language, native_libraries: dict):
     if os_ld_library_paths:
         all_library_paths += ":"
         all_library_paths += os_ld_library_paths
+    # Add working dir to library path of workers.
+    if working_dir:
+        all_library_paths += ":"
+        all_library_paths += working_dir
     os.environ[runtime_env_constants.LIBRARY_PATH_ENV_NAME] = all_library_paths


### PR DESCRIPTION
## Why are these changes needed?

When each worker has its own working directory, we need to add the independent working_dir to the LD_LIBRARY_PATH environment variable so that the worker can access and load the required resources.
But we don't contain independent working_dir in LD_LIBRARY_PATH now

## Related issue number

#560 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
