### PR TITLE
[Core][Runtime Env][9/N] Add allocated resources to Runtime Env Agent

### DIFF
--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -324,7 +324,6 @@ class RuntimeEnvAgent:
             log_files = runtime_env_config.get("log_files", [])
             # Use a separate logger for each job.
             per_job_logger = self.get_or_create_logger(request.job_id, log_files)
-            per_job_logger.info(f"Worker has resource :" f"{allocated_resource}")
             context = RuntimeEnvContext(env_vars=runtime_env.env_vars())
 
             # Warn about unrecognized fields in the runtime env.

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -305,9 +305,6 @@ class RuntimeEnvAgent:
             self._per_job_logger_cache[job_id] = per_job_logger
         return self._per_job_logger_cache[job_id]
 
-    def get_runtime_env_key(self, serialized_env, serialized_allocated_instances):
-        return serialized_env + serialized_allocated_instances
-
     async def GetOrCreateRuntimeEnv(self, request):
         self._logger.info(
             f"Got request from {request.source_process} to increase "

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -276,15 +276,15 @@ class RuntimeEnvAgent:
         for uri, uri_type in unused_uris:
             self._plugin_manager.plugins[str(uri_type)].uri_cache.mark_unused(uri)
 
-    def unused_runtime_env_processor(self, unused_runtime_env_key: str) -> None:
+    def unused_runtime_env_processor(self, unused_runtime_env: str) -> None:
         def delete_runtime_env():
-            del self._env_cache[unused_runtime_env_key]
+            del self._env_cache[unused_runtime_env]
             self._logger.info(
-                "Runtime env %s removed from env-level cache.", unused_runtime_env_key
+                "Runtime env %s removed from env-level cache.", unused_runtime_env
             )
 
-        if unused_runtime_env_key in self._env_cache:
-            if not self._env_cache[unused_runtime_env_key].success:
+        if unused_runtime_env in self._env_cache:
+            if not self._env_cache[unused_runtime_env].success:
                 loop = get_or_create_event_loop()
                 # Cache the bad runtime env result by ttl seconds.
                 loop.call_later(

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -115,44 +115,44 @@ class ReferenceTable:
             self._unused_uris_callback(unused_uris)
         return unused_uris
 
-    def _increase_reference_for_runtime_env(self, runtime_env_key: str):
-        default_logger.debug(f"Increase reference for runtime env {runtime_env_key}.")
-        self._runtime_env_reference[runtime_env_key] += 1
+    def _increase_reference_for_runtime_env(self, serialized_env: str):
+        default_logger.debug(f"Increase reference for runtime env {serialized_env}.")
+        self._runtime_env_reference[serialized_env] += 1
 
-    def _decrease_reference_for_runtime_env(self, runtime_env_key: str):
-        """Decrease reference count for the given [runtime_env_key]. Throw exception if we cannot decrement reference."""
-        default_logger.debug(f"Decrease reference for runtime env {runtime_env_key}.")
+    def _decrease_reference_for_runtime_env(self, serialized_env: str):
+        """Decrease reference count for the given [serialized_env]. Throw exception if we cannot decrement reference."""
+        default_logger.debug(f"Decrease reference for runtime env {serialized_env}.")
         unused = False
-        if self._runtime_env_reference[runtime_env_key] > 0:
-            self._runtime_env_reference[runtime_env_key] -= 1
-            if self._runtime_env_reference[runtime_env_key] == 0:
+        if self._runtime_env_reference[serialized_env] > 0:
+            self._runtime_env_reference[serialized_env] -= 1
+            if self._runtime_env_reference[serialized_env] == 0:
                 unused = True
-                del self._runtime_env_reference[runtime_env_key]
+                del self._runtime_env_reference[serialized_env]
         else:
-            default_logger.warning(f"Runtime env {runtime_env_key} does not exist.")
+            default_logger.warning(f"Runtime env {serialized_env} does not exist.")
             raise ValueError(
-                f"{runtime_env_key} cannot decrement reference since the reference count is 0"
+                f"{serialized_env} cannot decrement reference since the reference count is 0"
             )
         if unused:
-            default_logger.info(f"Unused runtime env {runtime_env_key}.")
-            self._unused_runtime_env_callback(runtime_env_key)
+            default_logger.info(f"Unused runtime env {serialized_env}.")
+            self._unused_runtime_env_callback(serialized_env)
 
     def increase_reference(
-        self, runtime_env: RuntimeEnv, runtime_env_key: str, source_process: str
+        self, runtime_env: RuntimeEnv, serialized_env: str, source_process: str
     ) -> None:
         if source_process in self._reference_exclude_sources:
             return
-        self._increase_reference_for_runtime_env(runtime_env_key)
+        self._increase_reference_for_runtime_env(serialized_env)
         uris = self._uris_parser(runtime_env)
         self._increase_reference_for_uris(uris)
 
     def decrease_reference(
-        self, runtime_env: RuntimeEnv, runtime_env_key: str, source_process: str
+        self, runtime_env: RuntimeEnv, serialized_env: str, source_process: str
     ) -> None:
         """Decrease reference count for runtime env and uri. Throw exception if decrement reference count fails."""
         if source_process in self._reference_exclude_sources:
             return
-        self._decrease_reference_for_runtime_env(runtime_env_key)
+        self._decrease_reference_for_runtime_env(serialized_env)
         uris = self._uris_parser(runtime_env)
         self._decrease_reference_for_uris(uris)
 
@@ -305,8 +305,8 @@ class RuntimeEnvAgent:
             self._per_job_logger_cache[job_id] = per_job_logger
         return self._per_job_logger_cache[job_id]
 
-    def get_runtime_env_key(self, serialized_env, allocated_instances_serialized_json):
-        return serialized_env + allocated_instances_serialized_json
+    def get_runtime_env_key(self, serialized_env, serialized_allocated_instances):
+        return serialized_env + serialized_allocated_instances
 
     async def GetOrCreateRuntimeEnv(self, request):
         self._logger.info(
@@ -319,10 +319,10 @@ class RuntimeEnvAgent:
         async def _setup_runtime_env(
             runtime_env: RuntimeEnv,
             runtime_env_config: RuntimeEnvConfig,
-            allocated_instances_serialized_json: str,
+            serialized_allocated_instances: str,
         ):
             allocated_resource: dict = json.loads(
-                allocated_instances_serialized_json or "{}"
+                serialized_allocated_instances or "{}"
             )
             log_files = runtime_env_config.get("log_files", [])
             # Use a separate logger for each job.
@@ -399,7 +399,7 @@ class RuntimeEnvAgent:
                     runtime_env_setup_task = _setup_runtime_env(
                         runtime_env,
                         runtime_env_config,
-                        request.allocated_instances_serialized_json,
+                        request.serialized_allocated_instances,
                     )
                     runtime_env_context = await asyncio.wait_for(
                         runtime_env_setup_task, timeout=setup_timeout_seconds
@@ -444,11 +444,15 @@ class RuntimeEnvAgent:
                 return True, runtime_env_context, None
 
         try:
-            serialized_env = request.serialized_runtime_env
-            runtime_env = RuntimeEnv.deserialize(serialized_env)
-            runtime_env_key = self.get_runtime_env_key(
-                serialized_env, request.allocated_instances_serialized_json
+            runtime_env = RuntimeEnv.deserialize(request.serialized_runtime_env)
+            runtime_env.set_serialized_allocated_instances(
+                request.serialized_allocated_instances,
             )
+            serialized_env = RuntimeEnv.serialize_combined(
+                request.serialized_runtime_env,
+                request.serialized_allocated_instances,
+            )
+
         except Exception as e:
             self._logger.exception(
                 "[Increase] Failed to parse runtime env: " f"{serialized_env}"
@@ -462,21 +466,21 @@ class RuntimeEnvAgent:
 
         # Increase reference
         self._reference_table.increase_reference(
-            runtime_env, runtime_env_key, request.source_process
+            runtime_env, serialized_env, request.source_process
         )
 
-        if runtime_env_key not in self._env_locks:
+        if serialized_env not in self._env_locks:
             # async lock to prevent the same env being concurrently installed
-            self._env_locks[runtime_env_key] = asyncio.Lock()
+            self._env_locks[serialized_env] = asyncio.Lock()
 
-        async with self._env_locks[runtime_env_key]:
-            if runtime_env_key in self._env_cache:
-                result = self._env_cache[runtime_env_key]
+        async with self._env_locks[serialized_env]:
+            if serialized_env in self._env_cache:
+                result = self._env_cache[serialized_env]
                 if result.success:
                     runtime_env_context = result.result
                     self._logger.info(
                         "Runtime env already created "
-                        f"successfully. Env: {runtime_env_key}, "
+                        f"successfully. Env: {serialized_env}, "
                     )
                     context = await self.trigger_pre_worker_startup(
                         runtime_env,
@@ -493,12 +497,12 @@ class RuntimeEnvAgent:
                     error_message = result.result
                     self._logger.info(
                         "Runtime env already failed. "
-                        f"Env: {runtime_env_key}, "
+                        f"Env: {serialized_env}, "
                         f"err: {error_message}"
                     )
                     # Recover the reference.
                     self._reference_table.decrease_reference(
-                        runtime_env, runtime_env_key, request.source_process
+                        runtime_env, serialized_env, request.source_process
                     )
                     return runtime_env_agent_pb2.GetOrCreateRuntimeEnvReply(
                         status=agent_manager_pb2.AGENT_RPC_STATUS_FAILED,
@@ -533,10 +537,10 @@ class RuntimeEnvAgent:
             if not successful:
                 # Recover the reference.
                 self._reference_table.decrease_reference(
-                    runtime_env, runtime_env_key, request.source_process
+                    runtime_env, serialized_env, request.source_process
                 )
             # Add the result to env cache.
-            self._env_cache[runtime_env_key] = CreatedEnvResult(
+            self._env_cache[serialized_env] = CreatedEnvResult(
                 successful,
                 runtime_env_context if successful else error_message,
                 creation_time_ms,
@@ -580,12 +584,15 @@ class RuntimeEnvAgent:
             )
 
         try:
-            runtime_env_key = self.get_runtime_env_key(
+            runtime_env.set_serialized_allocated_instances(
+                request.serialized_allocated_instances,
+            )
+            serialized_env = RuntimeEnv.serialize_combined(
                 request.serialized_runtime_env,
-                request.allocated_instances_serialized_json,
+                request.serialized_allocated_instances,
             )
             self._reference_table.decrease_reference(
-                runtime_env, runtime_env_key, request.source_process
+                runtime_env, serialized_env, request.source_process
             )
         except Exception as e:
             return runtime_env_agent_pb2.DeleteRuntimeEnvIfPossibleReply(

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -465,12 +465,22 @@ class RuntimeEnv(dict):
         else:
             return from_dict(data_class=data_class, data=self.__getitem__(name))
 
+    # NOTE(Jcaky): Set the serialized allocated instances (resources) as part of the RuntimeEnv.
+    # This method stores resource information, which will be used to enforce resource constraints
+    # for workers in container scenarios based on actor and task resources.
     def set_serialized_allocated_instances(self, value: Any) -> None:
         self.__setitem__("serialized_allocated_instances", value)
 
+    # NOTE(Jacky): Retrieve the serialized allocated instances (resources) stored in the RuntimeEnv.
+    # Returns the resource information if it exists; otherwise, returns None. This method provides
+    # access to the resource-related portion of the RuntimeEnv.
     def get_serialized_allocated_instances(self) -> Optional[str]:
         return self.get("serialized_allocated_instances", None)
 
+    # NOTE(Jacky): Deserialize a combined string of serialized RuntimeEnv and resource information into a RuntimeEnv object.
+    # The method separates the actual serialized RuntimeEnv from the resource information and integrates
+    # the resources as part of the RuntimeEnv. This design supports enforcing resource constraints for
+    # workers in container scenarios based on actor and task resources.
     @classmethod
     def deserialize(cls, serialized_runtime_env: str) -> "RuntimeEnv":  # noqa: F821
         last_brace_pos = serialized_runtime_env.rfind("&&")
@@ -495,6 +505,15 @@ class RuntimeEnv(dict):
     def serialize_combined(
         cls, serialized_runtime_env: str, serialized_allocated_instances
     ) -> str:
+        """Combines two serialized strings into a single serialized representation.
+
+        Args:
+            serialized_runtime_env (str): The serialized representation of the runtime environment.
+            serialized_allocated_instances (str): The serialized representation of the allocated instances.
+
+        Returns:
+            str: A combined serialized string, with the two inputs concatenated using "&&" as a separator.
+        """
         return serialized_runtime_env + "&&" + serialized_allocated_instances
 
     def to_dict(self) -> Dict:

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -468,6 +468,9 @@ class RuntimeEnv(dict):
     def set_serialized_allocated_instances(self, value: Any) -> None:
         self.__setitem__("serialized_allocated_instances", value)
 
+    def get_serialized_allocated_instances(self) -> Optional[str]:
+        return self.get("serialized_allocated_instances", None)
+
     @classmethod
     def deserialize(cls, serialized_runtime_env: str) -> "RuntimeEnv":  # noqa: F821
         last_brace_pos = serialized_runtime_env.rfind("&&")
@@ -475,7 +478,7 @@ class RuntimeEnv(dict):
             return cls(_validate=False, **json.loads(serialized_runtime_env))
         serialized_env = serialized_runtime_env[:last_brace_pos]
         serialized_allocated_instances = serialized_runtime_env[last_brace_pos + 2 :]
-        runtime_env = cls(_validate=False, **json.loads(serialized_runtime_env))
+        runtime_env = cls(_validate=False, **json.loads(serialized_env))
         runtime_env.set_serialized_allocated_instances(serialized_allocated_instances)
         return runtime_env
 

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -961,6 +961,31 @@ def test_runtime_env_interface():
     assert runtime_env.to_dict() == {}
 
 
+def test_runtime_env_interface_with_allocated_instances():
+    # Test the interface with allocated instances
+    runtime_env = RuntimeEnv(working_dir="/tmp/test")
+    allocated_instances = {"CPU": 1, "GPU": 2}
+    serialized_allocated_instances = json.dumps(allocated_instances)
+    runtime_env.set_serialized_allocated_instances(serialized_allocated_instances)
+    assert (
+        runtime_env.get_serialized_allocated_instances()
+        == serialized_allocated_instances
+    )
+    serialize_env_combined = RuntimeEnv.serialize_env_combined(
+        runtime_env.serialize(), serialized_allocated_instances
+    )
+    assert (
+        serialize_env_combined
+        == f"{runtime_env.serialize()}&&{serialized_allocated_instances}"
+    )
+    new_runtime_env = RuntimeEnv.deserialize(serialize_env_combined)
+    assert new_runtime_env.working_dir() == "/tmp/test"
+    assert (
+        new_runtime_env.get_serialized_allocated_instances()
+        == serialized_allocated_instances
+    )
+
+
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -963,7 +963,8 @@ def test_runtime_env_interface():
 
 def test_runtime_env_interface_with_allocated_instances():
     # Test the interface with allocated instances
-    runtime_env = RuntimeEnv(working_dir="/tmp/test")
+    working_dir = "s3://bucket/key.zip"
+    runtime_env = RuntimeEnv(working_dir=working_dir)
     allocated_instances = {"CPU": 1, "GPU": 2}
     serialized_allocated_instances = json.dumps(allocated_instances)
     runtime_env.set_serialized_allocated_instances(serialized_allocated_instances)
@@ -971,7 +972,7 @@ def test_runtime_env_interface_with_allocated_instances():
         runtime_env.get_serialized_allocated_instances()
         == serialized_allocated_instances
     )
-    serialize_env_combined = RuntimeEnv.serialize_env_combined(
+    serialize_env_combined = RuntimeEnv.serialize_combined(
         runtime_env.serialize(), serialized_allocated_instances
     )
     assert (
@@ -979,7 +980,7 @@ def test_runtime_env_interface_with_allocated_instances():
         == f"{runtime_env.serialize()}&&{serialized_allocated_instances}"
     )
     new_runtime_env = RuntimeEnv.deserialize(serialize_env_combined)
-    assert new_runtime_env.working_dir() == "/tmp/test"
+    assert new_runtime_env.working_dir() == "s3://bucket/key.zip"
     assert (
         new_runtime_env.get_serialized_allocated_instances()
         == serialized_allocated_instances

--- a/src/ray/common/ray_config_def.ant.h
+++ b/src/ray/common/ray_config_def.ant.h
@@ -28,3 +28,7 @@ RAY_CONFIG(uint64_t, expired_job_clusters_gc_interval_ms, 30000)
 // of the virtual cluster, the cleanup function can be delayed. It allows other handlers
 // executed first, and leaves some time for tasks to finish (before force killing them).
 RAY_CONFIG(uint64_t, local_node_cleanup_delay_interval_ms, 30000)
+
+// If enabled and worker stated in container, the container will add
+// resource limit.
+RAY_CONFIG(bool, worker_resource_limits_enabled, false)

--- a/src/ray/protobuf/runtime_env_agent.proto
+++ b/src/ray/protobuf/runtime_env_agent.proto
@@ -31,6 +31,7 @@ message GetOrCreateRuntimeEnvRequest {
   bytes job_id = 3;
   string source_process = 4;
   bytes worker_id = 5;
+  string allocated_instances_serialized_json = 6;
 }
 
 message GetOrCreateRuntimeEnvReply {
@@ -47,6 +48,7 @@ message DeleteRuntimeEnvIfPossibleRequest {
   string source_process = 2;
   bytes worker_id = 3;
   bytes job_id = 4;
+  string allocated_instances_serialized_json = 5;
 }
 
 message DeleteRuntimeEnvIfPossibleReply {

--- a/src/ray/protobuf/runtime_env_agent.proto
+++ b/src/ray/protobuf/runtime_env_agent.proto
@@ -31,7 +31,7 @@ message GetOrCreateRuntimeEnvRequest {
   bytes job_id = 3;
   string source_process = 4;
   bytes worker_id = 5;
-  string allocated_instances_serialized_json = 6;
+  string serialized_allocated_instances = 6;
 }
 
 message GetOrCreateRuntimeEnvReply {
@@ -48,7 +48,7 @@ message DeleteRuntimeEnvIfPossibleRequest {
   string source_process = 2;
   bytes worker_id = 3;
   bytes job_id = 4;
-  string allocated_instances_serialized_json = 5;
+  string serialized_allocated_instances = 5;
 }
 
 message DeleteRuntimeEnvIfPossibleReply {

--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -357,6 +357,10 @@ void LocalTaskManager::DispatchScheduledTasksToWorkers() {
         sched_cls_info.running_tasks.insert(spec.TaskId());
         // The local node has the available resources to run the task, so we should run
         // it.
+        std::string allocated_instances_serialized_json = "{}";
+        if (RayConfig::instance().worker_resource_limits_enabled()) {
+          allocated_instances_serialized_json = allocated_instances->SerializeAsJson();
+        }
         work->allocated_instances = allocated_instances;
         work->SetStateWaitingForWorker();
         bool is_detached_actor = spec.IsDetachedActor();
@@ -387,7 +391,8 @@ void LocalTaskManager::DispatchScheduledTasksToWorkers() {
                                          is_detached_actor,
                                          owner_address,
                                          runtime_env_setup_error_message);
-            });
+            },
+            allocated_instances_serialized_json);
         work_it++;
       }
     }

--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -357,9 +357,9 @@ void LocalTaskManager::DispatchScheduledTasksToWorkers() {
         sched_cls_info.running_tasks.insert(spec.TaskId());
         // The local node has the available resources to run the task, so we should run
         // it.
-        std::string allocated_instances_serialized_json = "{}";
+        std::string serialized_allocated_instances = "{}";
         if (RayConfig::instance().worker_resource_limits_enabled()) {
-          allocated_instances_serialized_json = allocated_instances->SerializeAsJson();
+          serialized_allocated_instances = allocated_instances->SerializeAsJson();
         }
         work->allocated_instances = allocated_instances;
         work->SetStateWaitingForWorker();
@@ -392,7 +392,7 @@ void LocalTaskManager::DispatchScheduledTasksToWorkers() {
                                          owner_address,
                                          runtime_env_setup_error_message);
             },
-            allocated_instances_serialized_json);
+            serialized_allocated_instances);
         work_it++;
       }
     }

--- a/src/ray/raylet/runtime_env_agent_client.cc
+++ b/src/ray/raylet/runtime_env_agent_client.cc
@@ -354,13 +354,12 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
   // Making HTTP call.
   // POST /get_or_create_runtime_env
   // Body = proto rpc::GetOrCreateRuntimeEnvRequest
-  void GetOrCreateRuntimeEnv(
-      const JobID &job_id,
-      const std::string &serialized_runtime_env,
-      const rpc::RuntimeEnvConfig &runtime_env_config,
-      GetOrCreateRuntimeEnvCallback callback,
-      const WorkerID &worker_id,
-      const std::string &allocated_instances_serialized_json) override {
+  void GetOrCreateRuntimeEnv(const JobID &job_id,
+                             const std::string &serialized_runtime_env,
+                             const rpc::RuntimeEnvConfig &runtime_env_config,
+                             GetOrCreateRuntimeEnvCallback callback,
+                             const WorkerID &worker_id,
+                             const std::string &serialized_allocated_instances) override {
     RetryInvokeOnNotFoundWithDeadline<rpc::GetOrCreateRuntimeEnvReply>(
         [=](SuccCallback<rpc::GetOrCreateRuntimeEnvReply> succ_callback,
             FailCallback fail_callback) {
@@ -370,7 +369,7 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
                                           succ_callback,
                                           fail_callback,
                                           worker_id,
-                                          allocated_instances_serialized_json);
+                                          serialized_allocated_instances);
         },
         /*succ_callback=*/
         [=](rpc::GetOrCreateRuntimeEnvReply reply) {
@@ -417,7 +416,7 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
       std::function<void(rpc::GetOrCreateRuntimeEnvReply)> succ_callback,
       std::function<void(ray::Status)> fail_callback,
       const WorkerID &worker_id,
-      const std::string &allocated_instances_serialized_json) {
+      const std::string &serialized_allocated_instances) {
     rpc::GetOrCreateRuntimeEnvRequest request;
     request.set_job_id(job_id.Hex());
     request.set_serialized_runtime_env(serialized_runtime_env);
@@ -425,7 +424,7 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
     if (!worker_id.IsNil()) {
       request.set_worker_id(worker_id.Hex());
     }
-    request.set_allocated_instances_serialized_json(allocated_instances_serialized_json);
+    request.set_serialized_allocated_instances(serialized_allocated_instances);
     std::string payload = request.SerializeAsString();
 
     auto session = Session::Create(
@@ -456,7 +455,7 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
       DeleteRuntimeEnvIfPossibleCallback callback,
       const WorkerID &worker_id,
       const JobID &job_id,
-      const std::string &allocated_instances_serialized_json) override {
+      const std::string &serialized_allocated_instances) override {
     RetryInvokeOnNotFoundWithDeadline<rpc::DeleteRuntimeEnvIfPossibleReply>(
         [=](SuccCallback<rpc::DeleteRuntimeEnvIfPossibleReply> succ_callback,
             FailCallback fail_callback) {
@@ -465,7 +464,7 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
                                                std::move(fail_callback),
                                                worker_id,
                                                job_id,
-                                               allocated_instances_serialized_json);
+                                               serialized_allocated_instances);
         },
         /*succ_callback=*/
         [=](rpc::DeleteRuntimeEnvIfPossibleReply reply) {
@@ -500,7 +499,7 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
       std::function<void(ray::Status)> fail_callback,
       const WorkerID &worker_id,
       const JobID &job_id,
-      const std::string &allocated_instances_serialized_json) {
+      const std::string &serialized_allocated_instances) {
     rpc::DeleteRuntimeEnvIfPossibleRequest request;
     request.set_serialized_runtime_env(serialized_runtime_env);
     request.set_source_process("raylet");
@@ -508,7 +507,7 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
       request.set_worker_id(worker_id.Hex());
     }
     request.set_job_id(job_id.Hex());
-    request.set_allocated_instances_serialized_json(allocated_instances_serialized_json);
+    request.set_serialized_allocated_instances(serialized_allocated_instances);
     std::string payload = request.SerializeAsString();
 
     auto session = Session::Create(

--- a/src/ray/raylet/runtime_env_agent_client.h
+++ b/src/ray/raylet/runtime_env_agent_client.h
@@ -74,7 +74,7 @@ class RuntimeEnvAgentClient {
       const rpc::RuntimeEnvConfig &runtime_env_config,
       GetOrCreateRuntimeEnvCallback callback,
       const WorkerID &worker_id,
-      const std::string &allocated_instances_serialized_json) = 0;
+      const std::string &serialized_allocated_instances) = 0;
 
   /// Request agent to decrease the runtime env reference. This API is not idempotent. The
   /// client automatically retries on network errors.
@@ -87,7 +87,7 @@ class RuntimeEnvAgentClient {
       DeleteRuntimeEnvIfPossibleCallback callback,
       const WorkerID &worker_id,
       const JobID &job_id,
-      const std::string &allocated_instances_serialized_json) = 0;
+      const std::string &serialized_allocated_instances) = 0;
 
   // NOTE: The service has another method `GetRuntimeEnvsInfo` but nobody in raylet uses
   // it.

--- a/src/ray/raylet/runtime_env_agent_client.h
+++ b/src/ray/raylet/runtime_env_agent_client.h
@@ -68,11 +68,13 @@ class RuntimeEnvAgentClient {
   /// \param[in] runtime_env_config Configuration details for the runtime environment.
   /// \param[in] callback The callback function.
   /// \param[in] worker_id The worker id which the runtime env is created for.
-  virtual void GetOrCreateRuntimeEnv(const JobID &job_id,
-                                     const std::string &serialized_runtime_env,
-                                     const rpc::RuntimeEnvConfig &runtime_env_config,
-                                     GetOrCreateRuntimeEnvCallback callback,
-                                     const WorkerID &worker_id) = 0;
+  virtual void GetOrCreateRuntimeEnv(
+      const JobID &job_id,
+      const std::string &serialized_runtime_env,
+      const rpc::RuntimeEnvConfig &runtime_env_config,
+      GetOrCreateRuntimeEnvCallback callback,
+      const WorkerID &worker_id,
+      const std::string &allocated_instances_serialized_json) = 0;
 
   /// Request agent to decrease the runtime env reference. This API is not idempotent. The
   /// client automatically retries on network errors.
@@ -80,10 +82,12 @@ class RuntimeEnvAgentClient {
   /// `RuntimeEnv::Serialize` method.
   /// \param[in] callback The callback function.
   /// \param[in] worker_id The worker id which the runtime env is created for.
-  virtual void DeleteRuntimeEnvIfPossible(const std::string &serialized_runtime_env,
-                                          DeleteRuntimeEnvIfPossibleCallback callback,
-                                          const WorkerID &worker_id,
-                                          const JobID &job_id) = 0;
+  virtual void DeleteRuntimeEnvIfPossible(
+      const std::string &serialized_runtime_env,
+      DeleteRuntimeEnvIfPossibleCallback callback,
+      const WorkerID &worker_id,
+      const JobID &job_id,
+      const std::string &allocated_instances_serialized_json) = 0;
 
   // NOTE: The service has another method `GetRuntimeEnvsInfo` but nobody in raylet uses
   // it.

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -249,7 +249,8 @@ void WorkerPool::AddWorkerProcess(
     const rpc::RuntimeEnvInfo &runtime_env_info,
     const std::vector<std::string> &dynamic_options,
     std::optional<absl::Duration> worker_startup_keep_alive_duration,
-    const WorkerID &worker_id) {
+    const WorkerID &worker_id,
+    const std::string &allocated_instances_serialized_json) {
   state.worker_processes.emplace(worker_startup_token_counter_,
                                  WorkerProcessInfo{/*is_pending_registration=*/true,
                                                    worker_type,
@@ -258,7 +259,8 @@ void WorkerPool::AddWorkerProcess(
                                                    runtime_env_info,
                                                    dynamic_options,
                                                    worker_startup_keep_alive_duration,
-                                                   worker_id});
+                                                   worker_id,
+                                                   allocated_instances_serialized_json});
 }
 
 void WorkerPool::RemoveWorkerProcess(State &state,
@@ -473,7 +475,8 @@ std::tuple<Process, StartupToken> WorkerPool::StartWorkerProcess(
     const std::string &serialized_runtime_env_context,
     const rpc::RuntimeEnvInfo &runtime_env_info,
     std::optional<absl::Duration> worker_startup_keep_alive_duration,
-    const WorkerID &worker_id) {
+    const WorkerID &worker_id,
+    const std::string &allocated_instances_serialized_json) {
   rpc::JobConfig *job_config = nullptr;
   if (!job_id.IsNil()) {
     auto it = all_jobs_.find(job_id);
@@ -543,7 +546,8 @@ std::tuple<Process, StartupToken> WorkerPool::StartWorkerProcess(
                    runtime_env_info,
                    dynamic_options,
                    worker_startup_keep_alive_duration,
-                   worker_id);
+                   worker_id,
+                   allocated_instances_serialized_json);
   StartupToken worker_startup_token = worker_startup_token_counter_;
   update_worker_startup_token_counter();
   if (IsIOWorkerType(worker_type)) {
@@ -605,7 +609,8 @@ void WorkerPool::MonitorStartingWorkerProcess(StartupToken proc_startup_token,
       process_failed_pending_registration_++;
       DeleteRuntimeEnvIfPossible(it->second.runtime_env_info.serialized_runtime_env(),
                                  job_id,
-                                 it->second.worker_id);
+                                 it->second.worker_id,
+                                 it->second.allocated_instances_serialized_json);
       RemoveWorkerProcess(state, proc_startup_token);
       if (IsIOWorkerType(worker_type)) {
         // Mark the I/O worker as failed.
@@ -1325,8 +1330,9 @@ WorkerUnfitForTaskReason WorkerPool::WorkerFitsForTask(
 }
 
 void WorkerPool::StartNewWorker(
-    const std::shared_ptr<PopWorkerRequest> &pop_worker_request) {
-  auto start_worker_process_fn = [this](
+    const std::shared_ptr<PopWorkerRequest> &pop_worker_request,
+    const std::string &allocated_instances_serialized_json) {
+  auto start_worker_process_fn = [this, allocated_instances_serialized_json](
                                      std::shared_ptr<PopWorkerRequest> pop_worker_request,
                                      const std::string &serialized_runtime_env_context,
                                      const WorkerID &worker_id = WorkerID::Nil()) {
@@ -1345,7 +1351,8 @@ void WorkerPool::StartNewWorker(
                            serialized_runtime_env_context,
                            pop_worker_request->runtime_env_info,
                            pop_worker_request->worker_startup_keep_alive_duration,
-                           worker_id);
+                           worker_id,
+                           allocated_instances_serialized_json);
     if (status == PopWorkerStatus::OK) {
       RAY_CHECK(proc.IsValid());
       WarnAboutSize();
@@ -1354,12 +1361,16 @@ void WorkerPool::StartNewWorker(
     } else if (status == PopWorkerStatus::TooManyStartingWorkerProcesses) {
       // TODO(jjyao) As an optimization, we don't need to delete the runtime env
       // but reuse it the next time we retry the request.
-      DeleteRuntimeEnvIfPossible(
-          serialized_runtime_env, pop_worker_request->job_id, worker_id);
+      DeleteRuntimeEnvIfPossible(serialized_runtime_env,
+                                 pop_worker_request->job_id,
+                                 worker_id,
+                                 allocated_instances_serialized_json);
       state.pending_start_requests.emplace_back(std::move(pop_worker_request));
     } else {
-      DeleteRuntimeEnvIfPossible(
-          serialized_runtime_env, pop_worker_request->job_id, worker_id);
+      DeleteRuntimeEnvIfPossible(serialized_runtime_env,
+                                 pop_worker_request->job_id,
+                                 worker_id,
+                                 allocated_instances_serialized_json);
       PopWorkerCallbackAsync(std::move(pop_worker_request->callback), nullptr, status);
     }
   };
@@ -1389,14 +1400,16 @@ void WorkerPool::StartNewWorker(
                 /*runtime_env_setup_error_message*/ setup_error_message);
           }
         },
-        worker_id);
+        worker_id,
+        allocated_instances_serialized_json);
   } else {
     start_worker_process_fn(pop_worker_request, "");
   }
 }
 
 void WorkerPool::PopWorker(const TaskSpecification &task_spec,
-                           const PopWorkerCallback &callback) {
+                           const PopWorkerCallback &callback,
+                           const std::string &allocated_instances_serialized_json) {
   RAY_LOG(DEBUG) << "Pop worker for task " << task_spec.TaskId() << " task name "
                  << task_spec.FunctionDescriptor()->ToString();
   // Code path of actor task.
@@ -1436,7 +1449,8 @@ void WorkerPool::PopWorker(const TaskSpecification &task_spec,
         }
         return callback(worker, status, runtime_env_setup_error_message);
       });
-  PopWorker(std::move(pop_worker_request));
+  PopWorker(std::move(pop_worker_request),
+            std::move(allocated_instances_serialized_json));
 }
 
 std::shared_ptr<WorkerInterface> WorkerPool::FindAndPopIdleWorker(
@@ -1478,12 +1492,13 @@ std::shared_ptr<WorkerInterface> WorkerPool::FindAndPopIdleWorker(
   return nullptr;
 }
 
-void WorkerPool::PopWorker(std::shared_ptr<PopWorkerRequest> pop_worker_request) {
+void WorkerPool::PopWorker(std::shared_ptr<PopWorkerRequest> pop_worker_request,
+                           const std::string &allocated_instances_serialized_json) {
   // If there's an idle worker that fits the task, use it.
   // Else, start a new worker.
   auto worker = FindAndPopIdleWorker(*pop_worker_request);
   if (worker == nullptr) {
-    StartNewWorker(pop_worker_request);
+    StartNewWorker(pop_worker_request, allocated_instances_serialized_json);
     return;
   }
   RAY_CHECK(worker->GetAssignedJobId().IsNil() ||
@@ -1583,8 +1598,10 @@ void WorkerPool::DisconnectWorker(const std::shared_ptr<WorkerInterface> &worker
       }
     }
 
-    DeleteRuntimeEnvIfPossible(
-        serialized_runtime_env, worker->GetAssignedJobId(), it->second.worker_id);
+    DeleteRuntimeEnvIfPossible(serialized_runtime_env,
+                               worker->GetAssignedJobId(),
+                               it->second.worker_id,
+                               it->second.allocated_instances_serialized_json);
     RemoveWorkerProcess(state, worker->GetStartupToken());
   }
   RAY_CHECK(RemoveWorker(state.registered_workers, worker));
@@ -1806,11 +1823,13 @@ WorkerPool::IOWorkerState &WorkerPool::GetIOWorkerStateFromWorkerType(
   UNREACHABLE;
 }
 
-void WorkerPool::GetOrCreateRuntimeEnv(const std::string &serialized_runtime_env,
-                                       const rpc::RuntimeEnvConfig &runtime_env_config,
-                                       const JobID &job_id,
-                                       const GetOrCreateRuntimeEnvCallback &callback,
-                                       const WorkerID &worker_id) {
+void WorkerPool::GetOrCreateRuntimeEnv(
+    const std::string &serialized_runtime_env,
+    const rpc::RuntimeEnvConfig &runtime_env_config,
+    const JobID &job_id,
+    const GetOrCreateRuntimeEnvCallback &callback,
+    const WorkerID &worker_id,
+    const std::string &allocated_instances_serialized_json) {
   RAY_LOG(INFO) << "GetOrCreateRuntimeEnv for job " << job_id << " with runtime_env "
                 << serialized_runtime_env << " worker id " << worker_id;
   runtime_env_agent_client_->GetOrCreateRuntimeEnv(
@@ -1833,12 +1852,15 @@ void WorkerPool::GetOrCreateRuntimeEnv(const std::string &serialized_runtime_env
                    /*setup_error_message=*/setup_error_message);
         }
       },
-      worker_id);
+      worker_id,
+      allocated_instances_serialized_json);
 }
 
-void WorkerPool::DeleteRuntimeEnvIfPossible(const std::string &serialized_runtime_env,
-                                            const JobID &job_id,
-                                            const WorkerID &worker_id) {
+void WorkerPool::DeleteRuntimeEnvIfPossible(
+    const std::string &serialized_runtime_env,
+    const JobID &job_id,
+    const WorkerID &worker_id,
+    const std::string &allocated_instances_serialized_json) {
   RAY_LOG(DEBUG) << "DeleteRuntimeEnvIfPossible " << serialized_runtime_env
                  << " for job id " << job_id << " worker id " << worker_id;
   if (!IsRuntimeEnvEmpty(serialized_runtime_env)) {
@@ -1851,7 +1873,8 @@ void WorkerPool::DeleteRuntimeEnvIfPossible(const std::string &serialized_runtim
           }
         },
         worker_id,
-        job_id);
+        job_id,
+        allocated_instances_serialized_json);
   }
 }
 

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1449,7 +1449,7 @@ void WorkerPool::PopWorker(const TaskSpecification &task_spec,
         }
         return callback(worker, status, runtime_env_setup_error_message);
       });
-  PopWorker(std::move(pop_worker_request), std::move(serialized_allocated_instances));
+  PopWorker(std::move(pop_worker_request), serialized_allocated_instances);
 }
 
 std::shared_ptr<WorkerInterface> WorkerPool::FindAndPopIdleWorker(

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -141,12 +141,11 @@ class WorkerPoolInterface {
   /// Case 1: An suitable worker was found in idle worker pool.
   /// Case 2: An suitable worker registered to raylet.
   /// The corresponding PopWorkerStatus will be passed to the callback.
-  /// \param allocated_instances_serialized_json The serialized json of the allocated
+  /// \param serialized_allocated_instances The serialized json of the allocated
   /// instances \return Void.
-  virtual void PopWorker(
-      const TaskSpecification &task_spec,
-      const PopWorkerCallback &callback,
-      const std::string &allocated_instances_serialized_json = "{}") = 0;
+  virtual void PopWorker(const TaskSpecification &task_spec,
+                         const PopWorkerCallback &callback,
+                         const std::string &serialized_allocated_instances = "{}") = 0;
   /// Add an idle worker to the pool.
   ///
   /// \param The idle worker to add.
@@ -432,7 +431,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// See interface.
   void PopWorker(const TaskSpecification &task_spec,
                  const PopWorkerCallback &callback,
-                 const std::string &allocated_instances_serialized_json = "{}") override;
+                 const std::string &serialized_allocated_instances = "{}") override;
 
   /// Try to prestart a number of workers suitable the given task spec. Prestarting
   /// is needed since core workers request one lease at a time, if starting is slow,
@@ -485,7 +484,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
 
   /// Internal implementation of PopWorker.
   void PopWorker(std::shared_ptr<PopWorkerRequest> pop_worker_request,
-                 const std::string &allocated_instances_serialized_json = "{}");
+                 const std::string &serialized_allocated_instances = "{}");
 
   // Find an idle worker that can serve the task. If found, pop it out and return it.
   // Otherwise, return nullptr.
@@ -500,7 +499,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   // Note: NONE of these methods guarantee that pop_worker_request.callback will be called
   // with the started worker. It may be called with any fitting workers.
   void StartNewWorker(const std::shared_ptr<PopWorkerRequest> &pop_worker_request,
-                      const std::string &allocated_instances_serialized_json = "{}");
+                      const std::string &serialized_allocated_instances = "{}");
 
  protected:
   void update_worker_startup_token_counter();
@@ -538,7 +537,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
       const rpc::RuntimeEnvInfo &runtime_env_info = rpc::RuntimeEnvInfo(),
       std::optional<absl::Duration> worker_startup_keep_alive_duration = std::nullopt,
       const WorkerID &worker_id = WorkerID::Nil(),
-      const std::string &allocated_instances_serialized_json = "{}");
+      const std::string &serialized_allocated_instances = "{}");
 
   /// The implementation of how to start a new worker process with command arguments.
   /// The lifetime of the process is tied to that of the returned object,
@@ -599,7 +598,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
     // The external worker id which is assigned to the worker process.
     WorkerID worker_id;
     // The allocated instances serialized json.
-    std::string allocated_instances_serialized_json;
+    std::string serialized_allocated_instances;
   };
 
   /// An internal data structure that maintains the pool state per language.
@@ -765,20 +764,19 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// assume that the worker process has tree worker instances totally.
 
   /// Create runtime env asynchronously by runtime env agent.
-  void GetOrCreateRuntimeEnv(
-      const std::string &serialized_runtime_env,
-      const rpc::RuntimeEnvConfig &runtime_env_config,
-      const JobID &job_id,
-      const GetOrCreateRuntimeEnvCallback &callback,
-      const WorkerID &worker_id = WorkerID::Nil(),
-      const std::string &allocated_instances_serialized_json = "{}");
+  void GetOrCreateRuntimeEnv(const std::string &serialized_runtime_env,
+                             const rpc::RuntimeEnvConfig &runtime_env_config,
+                             const JobID &job_id,
+                             const GetOrCreateRuntimeEnvCallback &callback,
+                             const WorkerID &worker_id = WorkerID::Nil(),
+                             const std::string &serialized_allocated_instances = "{}");
 
   /// Delete runtime env asynchronously by runtime env agent.
   void DeleteRuntimeEnvIfPossible(
       const std::string &serialized_runtime_env,
       const JobID &job_id,
       const WorkerID &worker_id = WorkerID::Nil(),
-      const std::string &allocated_instances_serialized_json = "{}");
+      const std::string &serialized_allocated_instances = "{}");
 
   void AddWorkerProcess(State &state,
                         rpc::WorkerType worker_type,
@@ -788,7 +786,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
                         const std::vector<std::string> &dynamic_options,
                         std::optional<absl::Duration> worker_startup_keep_alive_duration,
                         const WorkerID &worker_id,
-                        const std::string &allocated_instances_serialized_json);
+                        const std::string &serialized_allocated_instances);
 
   void RemoveWorkerProcess(State &state, const StartupToken &proc_startup_token);
 

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -141,9 +141,12 @@ class WorkerPoolInterface {
   /// Case 1: An suitable worker was found in idle worker pool.
   /// Case 2: An suitable worker registered to raylet.
   /// The corresponding PopWorkerStatus will be passed to the callback.
-  /// \return Void.
-  virtual void PopWorker(const TaskSpecification &task_spec,
-                         const PopWorkerCallback &callback) = 0;
+  /// \param allocated_instances_serialized_json The serialized json of the allocated
+  /// instances \return Void.
+  virtual void PopWorker(
+      const TaskSpecification &task_spec,
+      const PopWorkerCallback &callback,
+      const std::string &allocated_instances_serialized_json = "{}") = 0;
   /// Add an idle worker to the pool.
   ///
   /// \param The idle worker to add.
@@ -428,7 +431,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
 
   /// See interface.
   void PopWorker(const TaskSpecification &task_spec,
-                 const PopWorkerCallback &callback) override;
+                 const PopWorkerCallback &callback,
+                 const std::string &allocated_instances_serialized_json = "{}") override;
 
   /// Try to prestart a number of workers suitable the given task spec. Prestarting
   /// is needed since core workers request one lease at a time, if starting is slow,
@@ -480,7 +484,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   const NodeID &GetNodeID() const;
 
   /// Internal implementation of PopWorker.
-  void PopWorker(std::shared_ptr<PopWorkerRequest> pop_worker_request);
+  void PopWorker(std::shared_ptr<PopWorkerRequest> pop_worker_request,
+                 const std::string &allocated_instances_serialized_json = "{}");
 
   // Find an idle worker that can serve the task. If found, pop it out and return it.
   // Otherwise, return nullptr.
@@ -494,7 +499,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   //
   // Note: NONE of these methods guarantee that pop_worker_request.callback will be called
   // with the started worker. It may be called with any fitting workers.
-  void StartNewWorker(const std::shared_ptr<PopWorkerRequest> &pop_worker_request);
+  void StartNewWorker(const std::shared_ptr<PopWorkerRequest> &pop_worker_request,
+                      const std::string &allocated_instances_serialized_json = "{}");
 
  protected:
   void update_worker_startup_token_counter();
@@ -531,7 +537,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
       const std::string &serialized_runtime_env_context = "{}",
       const rpc::RuntimeEnvInfo &runtime_env_info = rpc::RuntimeEnvInfo(),
       std::optional<absl::Duration> worker_startup_keep_alive_duration = std::nullopt,
-      const WorkerID &worker_id = WorkerID::Nil());
+      const WorkerID &worker_id = WorkerID::Nil(),
+      const std::string &allocated_instances_serialized_json = "{}");
 
   /// The implementation of how to start a new worker process with command arguments.
   /// The lifetime of the process is tied to that of the returned object,
@@ -591,6 +598,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
     std::optional<absl::Duration> worker_startup_keep_alive_duration;
     // The external worker id which is assigned to the worker process.
     WorkerID worker_id;
+    // The allocated instances serialized json.
+    std::string allocated_instances_serialized_json;
   };
 
   /// An internal data structure that maintains the pool state per language.
@@ -756,16 +765,20 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// assume that the worker process has tree worker instances totally.
 
   /// Create runtime env asynchronously by runtime env agent.
-  void GetOrCreateRuntimeEnv(const std::string &serialized_runtime_env,
-                             const rpc::RuntimeEnvConfig &runtime_env_config,
-                             const JobID &job_id,
-                             const GetOrCreateRuntimeEnvCallback &callback,
-                             const WorkerID &worker_id = WorkerID::Nil());
+  void GetOrCreateRuntimeEnv(
+      const std::string &serialized_runtime_env,
+      const rpc::RuntimeEnvConfig &runtime_env_config,
+      const JobID &job_id,
+      const GetOrCreateRuntimeEnvCallback &callback,
+      const WorkerID &worker_id = WorkerID::Nil(),
+      const std::string &allocated_instances_serialized_json = "{}");
 
   /// Delete runtime env asynchronously by runtime env agent.
-  void DeleteRuntimeEnvIfPossible(const std::string &serialized_runtime_env,
-                                  const JobID &job_id,
-                                  const WorkerID &worker_id = WorkerID::Nil());
+  void DeleteRuntimeEnvIfPossible(
+      const std::string &serialized_runtime_env,
+      const JobID &job_id,
+      const WorkerID &worker_id = WorkerID::Nil(),
+      const std::string &allocated_instances_serialized_json = "{}");
 
   void AddWorkerProcess(State &state,
                         rpc::WorkerType worker_type,
@@ -774,7 +787,8 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
                         const rpc::RuntimeEnvInfo &runtime_env_info,
                         const std::vector<std::string> &dynamic_options,
                         std::optional<absl::Duration> worker_startup_keep_alive_duration,
-                        const WorkerID &worker_id);
+                        const WorkerID &worker_id,
+                        const std::string &allocated_instances_serialized_json);
 
   void RemoveWorkerProcess(State &state, const StartupToken &proc_startup_token);
 


### PR DESCRIPTION
## Why are these changes needed?
Currently, Runtime Env Agent is not aware of the resources of actors and tasks, so it is not possible to limit the use of resources in `worker in container` mode. 
So we add the resource as part of RuntimeEnv to the cache of RuntimeEnv.

We do something as follows

- add serialized `allocated_instances` to runtime env agent proto.
- Change the cache key of all Runtime Env from `serialized_runtime_env` to `runtime_env_key`, `runtime_env_key`, where `runtime_env_key` is defined as `serialized_runtime_env` + `allocated_instances_serialized_json`
- use `worker_resource_limits_enabled` config to control whether allocated resources are serialized, the default value is `False`, the default value of `allocated_instances_serialized_json` is `"{}"`

#563 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
