### PR TITLE
[Core][Runtime Env][10/N] Support base worker in container in Runtime Env

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -560,3 +560,6 @@ GCS_ADDRESS_KEY = STORAGE_NAMESPACE + "GcsServerAddress"
 # `services.py::wait_for_redis_to_start()` and
 # `services.py::create_redis_client()`
 START_REDIS_WAIT_RETRIES = env_integer("RAY_START_REDIS_WAIT_RETRIES", 60)
+
+# The default pyenv root
+RAY_DEFAULT_PYENV_ROOT = "/home/admin/.pyenv"

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -351,7 +351,7 @@ class RuntimeEnvAgent:
                 per_job_logger,
             )
 
-            # Then within the working dir, create the other plugins.
+            # Then within the working dir, create the other plugins and skip container plugin.
             working_dir_uri_or_none = runtime_env.working_dir_uri()
             with self._working_dir_plugin.with_working_dir_env(working_dir_uri_or_none):
                 """Run setup for each plugin unless it has already been cached."""
@@ -359,11 +359,23 @@ class RuntimeEnvAgent:
                     plugin_setup_context
                 ) in self._plugin_manager.sorted_plugin_setup_contexts():
                     plugin = plugin_setup_context.class_instance
+                    if plugin.name == ContainerPlugin.name:
+                        continue
                     if plugin.name != WorkingDirPlugin.name:
                         uri_cache = plugin_setup_context.uri_cache
                         await create_for_plugin_if_needed(
                             runtime_env, plugin, uri_cache, context, per_job_logger
                         )
+            # Container plugin should be created after all other plugins.
+            container_ctx = self._plugin_manager.plugins[ContainerPlugin.name]
+            await create_for_plugin_if_needed(
+                runtime_env,
+                container_ctx.class_instance,
+                container_ctx.uri_cache,
+                context,
+                per_job_logger,
+            )
+
             return context
 
         async def _create_runtime_env_with_retry(

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -359,6 +359,8 @@ class RuntimeEnvAgent:
                     plugin_setup_context
                 ) in self._plugin_manager.sorted_plugin_setup_contexts():
                     plugin = plugin_setup_context.class_instance
+                    # Container plugin should be created after all other plugins, because the container plugin may depends on others.
+                    # So we skip the container plugin here.
                     if plugin.name == ContainerPlugin.name:
                         continue
                     if plugin.name != WorkingDirPlugin.name:
@@ -366,7 +368,7 @@ class RuntimeEnvAgent:
                         await create_for_plugin_if_needed(
                             runtime_env, plugin, uri_cache, context, per_job_logger
                         )
-            # Container plugin should be created after all other plugins.
+            # Container plugin should be created after all other plugins, because the container plugin may depends on others.
             container_ctx = self._plugin_manager.plugins[ContainerPlugin.name]
             await create_for_plugin_if_needed(
                 runtime_env,

--- a/python/ray/_private/runtime_env/constants.py
+++ b/python/ray/_private/runtime_env/constants.py
@@ -52,10 +52,9 @@ CONTAINER_ENV_PLACEHOLDER = "$CONTAINER_ENV_PLACEHOLDER"
 RAY_JAVA_JARS_DIRS = "RAY_JAVA_JARS_DIRS"
 
 # Whether podman integrate nydus
-RAY_PODMAN_UES_NYDUS = env_bool("RAY_PODMAN_UES_NYDUS", False)
+RAY_PODMAN_UES_NYDUS = env_bool("RAY_PODMAN_UES_NYDUS", True)
 
 # Default mount points for Podman containers.
-# The format allows either "{source_path}:{target_path}" for bind mounts
-# or "{path}" (equivalent to source=target) for symmetric mounts.
-# Entries are separated by semicolons (e.g., "A:A;B:C;D" where "D" implies "D:D").
+# The format allows "{source_path}:{target_path}" for bind mounts
+# Entries are separated by semicolons (e.g., "A:A;B:C").
 RAY_PODMAN_DEFAULT_MOUNT_POINTS = os.environ.get("RAY_PODMAN_DEFAULT_MOUNT_POINTS", "")

--- a/python/ray/_private/runtime_env/constants.py
+++ b/python/ray/_private/runtime_env/constants.py
@@ -52,7 +52,7 @@ CONTAINER_ENV_PLACEHOLDER = "$CONTAINER_ENV_PLACEHOLDER"
 RAY_JAVA_JARS_DIRS = "RAY_JAVA_JARS_DIRS"
 
 # Whether podman integrate nydus
-RAY_PODMAN_UES_NYDUS = env_bool("RAY_PODMAN_UES_NYDUS", True)
+RAY_PODMAN_UES_NYDUS = env_bool("RAY_PODMAN_UES_NYDUS", False)
 
 # Default mount points for Podman containers.
 # The format allows either "{source_path}:{target_path}" for bind mounts

--- a/python/ray/_private/runtime_env/constants.py
+++ b/python/ray/_private/runtime_env/constants.py
@@ -54,9 +54,6 @@ INTERNAL_SYSTEM_CONFIG_DYNAMIC_FILE = "/lib/libsysconf-alipay.so"
 # the key for java jar dirs in the environment variable.
 RAY_JAVA_JARS_DIRS = "RAY_JAVA_JARS_DIRS"
 
-# Whether to use ray whl when `install_ray` is True in the container.
-RAY_USE_WHL_PACKAGE = env_bool("RAY_USE_WHL_PACKAGE", False)
-
 # Whether podman integrate nydus
 RAY_PODMAN_UES_NYDUS = env_bool("RAY_PODMAN_UES_NYDUS", True)
 

--- a/python/ray/_private/runtime_env/constants.py
+++ b/python/ray/_private/runtime_env/constants.py
@@ -1,5 +1,6 @@
 import sys
 import os
+from ray._private.ray_constants import env_bool, env_integer
 
 # Env var set by job manager to pass runtime env and metadata to subprocess
 RAY_JOB_CONFIG_JSON_ENV_VAR = "RAY_JOB_CONFIG_JSON_ENV_VAR"
@@ -42,3 +43,29 @@ else:
     LIBRARY_PATH_ENV_NAME = "PATH"
 
 PRELOAD_ENV_NAME = "LD_PRELOAD"
+
+
+# Container or image uri plugin placeholder, which will be replaced by env_vars.
+CONTAINER_ENV_PLACEHOLDER = "$CONTAINER_ENV_PLACEHOLDER"
+
+# ANT-INTERNAL: Alipay internal system config dynamic depot
+INTERNAL_SYSTEM_CONFIG_DYNAMIC_FILE = "/lib/libsysconf-alipay.so"
+
+# the key for java jar dirs in the environment variable.
+RAY_JAVA_JARS_DIRS = "RAY_JAVA_JARS_DIRS"
+
+# Whether to use ray whl when `install_ray` is True in the container.
+RAY_USE_WHL_PACKAGE = env_bool("RAY_USE_WHL_PACKAGE", False)
+
+# Whether podman integrate nydus
+RAY_PODMAN_UES_NYDUS = env_bool("RAY_PODMAN_UES_NYDUS", True)
+
+# The system log dir
+RAY_PODMAN_SYSTEM_LOG_DIR = os.environ.get(
+    "RAY_PODMAN_SYSTEM_LOG_DIR", "/home/admin/logs"
+)
+
+# Apsara Cloud system config dir
+RAY_PODMAN_APSARA_SYSTEM_CONFIG_DIR = os.environ.get(
+    "RAY_PODMAN_APSARA_SYSTEM_CONFIG_DIR", "/apsara"
+)

--- a/python/ray/_private/runtime_env/constants.py
+++ b/python/ray/_private/runtime_env/constants.py
@@ -69,3 +69,8 @@ RAY_PODMAN_SYSTEM_LOG_DIR = os.environ.get(
 RAY_PODMAN_APSARA_SYSTEM_CONFIG_DIR = os.environ.get(
     "RAY_PODMAN_APSARA_SYSTEM_CONFIG_DIR", "/apsara"
 )
+
+# Ant resources dir
+RAY_PODMAN_ANT_RESOURCES_DIR = os.environ.get(
+    "RAY_PODMAN_ANT_RESOURCES_DIR", "/home/admin/ray-pack"
+)

--- a/python/ray/_private/runtime_env/constants.py
+++ b/python/ray/_private/runtime_env/constants.py
@@ -48,26 +48,14 @@ PRELOAD_ENV_NAME = "LD_PRELOAD"
 # Container or image uri plugin placeholder, which will be replaced by env_vars.
 CONTAINER_ENV_PLACEHOLDER = "$CONTAINER_ENV_PLACEHOLDER"
 
-# ANT-INTERNAL: Alipay internal system config dynamic depot
-INTERNAL_SYSTEM_CONFIG_DYNAMIC_FILE = "/lib/libsysconf-alipay.so"
-
 # the key for java jar dirs in the environment variable.
 RAY_JAVA_JARS_DIRS = "RAY_JAVA_JARS_DIRS"
 
 # Whether podman integrate nydus
 RAY_PODMAN_UES_NYDUS = env_bool("RAY_PODMAN_UES_NYDUS", True)
 
-# The system log dir
-RAY_PODMAN_SYSTEM_LOG_DIR = os.environ.get(
-    "RAY_PODMAN_SYSTEM_LOG_DIR", "/home/admin/logs"
-)
-
-# Apsara Cloud system config dir
-RAY_PODMAN_APSARA_SYSTEM_CONFIG_DIR = os.environ.get(
-    "RAY_PODMAN_APSARA_SYSTEM_CONFIG_DIR", "/apsara"
-)
-
-# Ant resources dir
-RAY_PODMAN_ANT_RESOURCES_DIR = os.environ.get(
-    "RAY_PODMAN_ANT_RESOURCES_DIR", "/home/admin/ray-pack"
-)
+# Default mount points for Podman containers.
+# The format allows either "{source_path}:{target_path}" for bind mounts
+# or "{path}" (equivalent to source=target) for symmetric mounts.
+# Entries are separated by semicolons (e.g., "A:A;B:C;D" where "D" implies "D:D").
+RAY_PODMAN_DEFAULT_MOUNT_POINTS = os.environ.get("RAY_PODMAN_DEFAULT_MOUNT_POINTS", "")

--- a/python/ray/_private/runtime_env/context.py
+++ b/python/ray/_private/runtime_env/context.py
@@ -145,7 +145,6 @@ class RuntimeEnvContext:
 
         # excute worker process in container
         if "container_command" in self.container:
-            container_command = self.container["container_command"]
             # try update container command
             container_command = try_update_container_command(
                 language,

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -1,12 +1,48 @@
 import logging
 import os
+import json
 from typing import List, Optional
-
+import ray
+import ray._private.runtime_env.constants as runtime_env_constants
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 from ray._private.runtime_env.utils import check_output_cmd
 
+from ray._private.utils import (
+    get_ray_site_packages_path,
+    get_pyenv_path,
+)
+
 default_logger = logging.getLogger(__name__)
+
+# NOTE(chenk008): it is moved from setup_worker. And it will be used
+# to setup resource limit.
+def parse_allocated_resource(allocated_instances_serialized_json):
+    container_resource_args = []
+    allocated_resource = json.loads(allocated_instances_serialized_json)
+    if "CPU" in allocated_resource.keys():
+        cpu_resource = allocated_resource["CPU"]
+        if isinstance(cpu_resource, list):
+            # cpuset: because we may split one cpu core into some pieces,
+            # we need set cpuset.cpu_exclusive=0 and set cpuset-cpus
+            cpu_ids = []
+            cpus = 0
+            for idx, val in enumerate(cpu_resource):
+                if val > 0:
+                    cpu_ids.append(idx)
+                    cpus += val
+            container_resource_args.append("--cpus=" + str(int(cpus / 10000)))
+            container_resource_args.append(
+                "--cpuset-cpus=" + ",".join(str(e) for e in cpu_ids)
+            )
+        else:
+            # cpushare
+            container_resource_args.append("--cpus=" + str(int(cpu_resource / 10000)))
+    if "memory" in allocated_resource.keys():
+        container_resource_args.append(
+            "--memory=" + str(int(allocated_resource["memory"] / 10000 / 10000)) + "m"
+        )
+    return container_resource_args
 
 
 async def _create_impl(image_uri: str, logger: logging.Logger):
@@ -27,6 +63,203 @@ async def _create_impl(image_uri: str, logger: logging.Logger):
     logger.info("Pulling image %s", image_uri)
     worker_path = await check_output_cmd(pull_image_cmd, logger=logger)
     return worker_path.strip()
+
+
+container_placeholder = runtime_env_constants.CONTAINER_ENV_PLACEHOLDER
+
+
+def _modify_container_context_impl(
+    runtime_env: "RuntimeEnv",  # noqa: F821
+    context: RuntimeEnvContext,
+    ray_tmp_dir: str,
+    worker_path: str,
+    logger: Optional[logging.Logger] = default_logger,
+):
+    if not runtime_env.py_container_image():
+        return
+    context.override_worker_entrypoint = worker_path
+
+    logger.info(f"container setup for {runtime_env}")
+    container_option = runtime_env.get("container")
+
+    # Use the user's python executable if py_executable is not None.
+    py_executable = container_option.get("py_executable")
+
+    container_driver = "podman"
+    # todo add cgroup config
+    container_command = [
+        container_driver,
+        "run",
+        "--rm",
+        "-v",
+        ray_tmp_dir + ":" + ray_tmp_dir,
+        "--cgroup-manager=cgroupfs",
+        "--network=host",
+        "--pid=host",
+        "--ipc=host",
+        "--env-host",
+        "--cgroups=no-conmon",  # ANT-INTERNAL
+        # NOTE(zcin): Mounted volumes in rootless containers are
+        # owned by the user `root`. The user on host (which will
+        # usually be `ray` if this is being run in a ray docker
+        # image) who started the container is mapped using user
+        # namespaces to the user `root` in a rootless container. In
+        # order for the Ray Python worker to access the mounted ray
+        # tmp dir, we need to use keep-id mode which maps the user
+        # as itself (instead of as `root`) into the container.
+        # https://www.redhat.com/sysadmin/rootless-podman-user-namespace-modes
+        "--userns=keep-id",
+    ]
+
+    # Note(Jacky): If the same target_path is present in the container mount,
+    # the image will not start due to the duplicate mount target path error,
+    # so we create a reverse dict mapping,
+    # which can modify the latest source_path.
+    container_to_host_mount_dict = {}
+
+    # in ANT-INTERNAL, we need mount /home/admin/ray-pack,
+    # because some config generated on starting
+    tmp_dir = "/home/admin/ray-pack"
+    if os.path.exists(tmp_dir):
+        container_to_host_mount_dict[tmp_dir] = tmp_dir
+
+    context.env_vars["RAY_RAYLET_PID"] = os.getenv("RAY_RAYLET_PID")
+    """
+    container_command.extend(
+        parse_allocated_resource(serialized_allocated_resource_instances)
+    )
+    """
+    # we need 'sudo' and 'admin', mount logs
+    container_command = ["sudo", "-E"] + container_command
+    container_command.append("-u")
+    user = container_option.get("user")
+    if user:
+        container_command.append(user)
+    else:
+        container_command.append("admin")
+    container_command.append("-w")
+    if context.working_dir:
+        container_command.append(context.working_dir)
+    else:
+        container_command.append(os.getcwd())
+    container_command.append("--cap-add=AUDIT_WRITE")
+    if os.path.exists(runtime_env_constants.RAY_PODMAN_SYSTEM_LOG_DIR):
+        log_dir = runtime_env_constants.RAY_PODMAN_SYSTEM_LOG_DIR
+        if container_option.get("customize_log_dir"):
+            customize_log_path = container_option.get("customize_log_dir")
+            if not os.path.exists(customize_log_path):
+                os.makedirs(customize_log_path)
+                container_to_host_mount_dict[log_dir] = customize_log_path
+                ray_log_dir = os.path.join(log_dir, "ray_logs")
+                container_to_host_mount_dict[ray_log_dir] = ray_log_dir
+                container_to_host_mount_dict[os.path.join(log_dir, "share")] = log_dir
+        else:
+            container_to_host_mount_dict[log_dir] = log_dir
+    if os.path.exists(runtime_env_constants.RAY_PODMAN_APSARA_SYSTEM_CONFIG_DIR):
+        aspara_system_config_dir = (
+            runtime_env_constants.RAY_PODMAN_APSARA_SYSTEM_CONFIG_DIR
+        )
+        container_to_host_mount_dict[
+            aspara_system_config_dir
+        ] = aspara_system_config_dir
+
+    host_site_packages_path = get_ray_site_packages_path()
+    if py_executable:
+        # Replace the pyenv path in container to
+        # avoid overwriting the user's pyenv.
+        pyenv_folder = "ray/.pyenv"
+    else:
+        pyenv_folder = ".pyenv"
+    host_pyenv_path = get_pyenv_path()
+    container_pyenv_path = host_pyenv_path.replace(".pyenv", pyenv_folder)
+    container_to_host_mount_dict[container_pyenv_path] = host_pyenv_path
+    context.pyenv_folder = pyenv_folder
+    container_to_host_mount_dict[host_site_packages_path] = host_site_packages_path
+
+    if os.path.exists(runtime_env_constants.INTERNAL_SYSTEM_CONFIG_DYNAMIC_FILE):
+        system_dynamic_config_file_path = (
+            runtime_env_constants.INTERNAL_SYSTEM_CONFIG_DYNAMIC_FILE
+        )
+        container_to_host_mount_dict[
+            system_dynamic_config_file_path
+        ] = system_dynamic_config_file_path
+
+    # For loop `run options` and append each item to the command line of podman
+    if runtime_env.py_container_run_options():
+        run_options_list = runtime_env.py_container_run_options()
+        index = 0
+        while index < len(run_options_list):
+            run_option = run_options_list[index]
+            if run_option == "-v":
+                if index == len(run_options_list) - 1:
+                    raise RuntimeError(
+                        "Incorrect mount path command, "
+                        "please check the container field "
+                        "in the run_options field mount path, "
+                        "`-v host_path:container_path`."
+                    )
+                next_option = run_options_list[index + 1]
+                paths = next_option.split(":")
+                if len(paths) != 2:
+                    raise RuntimeError(
+                        "Incorrect mount path command, "
+                        "please check the container field "
+                        "in the run_options field mount path, "
+                        f"got {next_option}"
+                    )
+                source_path = paths[0].strip()
+                target_path = paths[1].strip()
+                # Iterate over the key of
+                # 'container_to_host_mount_dict'
+                # to find if target_path already exists
+                container_to_host_mount_dict[target_path] = source_path
+                index += 2
+            else:
+                container_command.append(run_option)
+                index += 1
+
+    for (
+        target_path,
+        source_path,
+    ) in container_to_host_mount_dict.items():
+        container_command.append("-v")
+        container_command.append(f"{source_path}:{target_path}")
+    if container_option.get("native_libraries"):
+        container_native_libraries = container_option["native_libraries"]
+        context.native_libraries["code_search_path"].append(container_native_libraries)
+    context.env_vars["RAY_JOB_DATA_DIR_BASE"] = os.getenv("RAY_JOB_DATA_DIR_BASE", "")
+    # unset PYENV_VERSION, the image may use pyenv with other python.
+    context.env_vars["PYENV_VERSION"] = ""
+    # Append env vars to container
+    if context.env_vars.get("PYTHONPATH") and py_executable:
+        context.env_vars["PYTHONPATH"] = context.env_vars["PYTHONPATH"].replace(
+            ".pyenv", "ray/.pyenv"
+        )
+    container_command.append(container_placeholder)
+    container_command.append("--entrypoint")
+    # Some docker image use conda to run python, it depend on ~/.bashrc.
+    # So we need to use bash as container entrypoint.
+    container_command.append("bash")
+
+    # If podman integrate nydus, we use nydus image as rootfs
+    if runtime_env_constants.RAY_PODMAN_UES_NYDUS:
+        container_command.append("--rootfs")
+        container_command.append(runtime_env.py_container_image() + ":O")
+    else:
+        container_command.append(runtime_env.py_container_image())
+    container_command.extend(["-l", "-c"])
+    context.container["container_command"] = container_command
+
+    if py_executable:
+        context.py_executable = py_executable
+    # Example:
+    # sudo -E podman run -v /tmp/ray:/tmp/ray
+    # --cgroup-manager=cgroupfs --network=host --pid=host --ipc=host --env-host --cgroups=no-conmon
+    # --userns=keep-id -v /home/admin/ray-pack:/home/admin/ray-pack --env RAY_RAYLET_PID=23478 --env RAY_JOB_ID=$RAY_JOB_ID
+    # --entrypoint python rayproject/ray:nightly-py39
+    logger.info(
+        "start worker in container with prefix: {}".format(" ".join(container_command))
+    )
 
 
 def _modify_context_impl(
@@ -155,18 +388,6 @@ class ContainerPlugin(RuntimeEnvPlugin):
     def __init__(self, ray_tmp_dir: str):
         self._ray_tmp_dir = ray_tmp_dir
 
-    async def create(
-        self,
-        uri: Optional[str],
-        runtime_env: "RuntimeEnv",  # noqa: F821
-        context: RuntimeEnvContext,
-        logger: logging.Logger,
-    ) -> float:
-        if not runtime_env.has_py_container() or not runtime_env.py_container_image():
-            return
-
-        self.worker_path = await _create_impl(runtime_env.py_container_image(), logger)
-
     def modify_context(
         self,
         uris: List[str],
@@ -185,11 +406,10 @@ class ContainerPlugin(RuntimeEnvPlugin):
                 "versions."
             )
 
-        _modify_context_impl(
-            runtime_env.py_container_image(),
-            runtime_env.py_container_worker_path() or self.worker_path,
-            runtime_env.py_container_run_options(),
-            context,
-            logger,
-            self._ray_tmp_dir,
+        _modify_container_context_impl(
+            runtime_env=runtime_env,
+            context=context,
+            ray_tmp_dir=self._ray_tmp_dir,
+            worker_path=runtime_env.py_container_worker_path(),
+            logger=logger,
         )

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -13,8 +13,7 @@ from ray._private.utils import (
     get_pyenv_path,
     try_parse_default_mount_points,
     try_parse_container_run_options,
-    try_update_env_vars,
-    is_py_executable_startswith_pyenv,
+    try_update_runtime_env_vars,
 )
 
 default_logger = logging.getLogger(__name__)
@@ -120,7 +119,7 @@ def _modify_container_context_impl(
     # to avoid overwriting the container's internal PYENV environment
     # (which defaults to `/home/admin/.pyenv`).
     redirected_pyenv_folder = None
-    if py_executable and is_py_executable_startswith_pyenv(py_executable):
+    if py_executable and py_executable.startswith(get_pyenv_path()):
         redirected_pyenv_folder = "ray/.pyenv"
 
     host_pyenv_path = get_pyenv_path()
@@ -154,8 +153,8 @@ def _modify_container_context_impl(
         context.native_libraries["code_search_path"].append(container_native_libraries)
 
     # Environment variables to set in container
-    context.env_vars = try_update_env_vars(
-        context.env_vars, py_executable, redirected_pyenv_folder
+    context.env_vars = try_update_runtime_env_vars(
+        context.env_vars, redirected_pyenv_folder
     )
 
     # Append the container_placeholder as a placeholder to the command.

--- a/python/ray/_private/runtime_env/pip.py
+++ b/python/ray/_private/runtime_env/pip.py
@@ -16,6 +16,8 @@ from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 from ray._private.runtime_env.utils import check_output_cmd
 from ray._private.utils import get_directory_size_bytes, try_to_create_directory
 
+from ray._private.runtime_env.working_dir import set_pythonpath_in_context
+
 default_logger = logging.getLogger(__name__)
 
 
@@ -384,6 +386,13 @@ class PipPlugin(RuntimeEnvPlugin):
                 "installing the runtime_env `pip` packages."
             )
         context.py_executable = virtualenv_python
+        # We get the path of the ray base environment, virtual environment,
+        # and virtual environment on the current pod, and add them to `PYTHONPATH`
+        all_packages = virtualenv_utils.get_all_packages_paths(
+            target_dir, runtime_env.pip_config().get("python_version")
+        )
+        for package in all_packages:
+            set_pythonpath_in_context(package, context)
         context.command_prefix += virtualenv_utils.get_virtualenv_activate_command(
             target_dir
         )

--- a/python/ray/_private/runtime_env/virtualenv_utils.py
+++ b/python/ray/_private/runtime_env/virtualenv_utils.py
@@ -4,8 +4,8 @@ import sys
 import platform
 from ray._private.utils import (
     get_ray_site_packages_path,
-    get_current_python,
-    get_specify_python,
+    get_current_python_info,
+    get_specify_python_info,
 )
 from ray._private.runtime_env.utils import check_output_cmd
 import logging
@@ -118,9 +118,9 @@ async def create_or_get_virtualenv(path: str, cwd: str, logger: logging.Logger):
 def get_all_packages_paths(target_dir: str, python_version: str = None) -> List:
     ray_package_path = None
     if not python_version:
-        _, host_site_packages_dir, python_version = get_current_python()
+        _, host_site_packages_dir, python_version = get_current_python_info()
     else:
-        _, host_site_packages_dir = get_specify_python(python_version)
+        _, host_site_packages_dir = get_specify_python_info(python_version)
 
     if platform.python_version().startswith(python_version):
         # We need this path because in the development environment,

--- a/python/ray/_private/runtime_env/virtualenv_utils.py
+++ b/python/ray/_private/runtime_env/virtualenv_utils.py
@@ -1,6 +1,12 @@
 """Utils to detect runtime environment."""
 
 import sys
+import platform
+from ray._private.utils import (
+    get_ray_site_packages_path,
+    get_current_python,
+    get_specify_python,
+)
 from ray._private.runtime_env.utils import check_output_cmd
 import logging
 import os
@@ -107,3 +113,29 @@ async def create_or_get_virtualenv(path: str, cwd: str, logger: logging.Logger):
             virtualenv_path,
         )
     await check_output_cmd(create_venv_cmd, logger=logger, cwd=cwd, env=env)
+
+
+def get_all_packages_paths(target_dir: str, python_version: str = None) -> List:
+    ray_package_path = None
+    if not python_version:
+        _, host_site_packages_dir, python_version = get_current_python()
+    else:
+        _, host_site_packages_dir = get_specify_python(python_version)
+
+    if platform.python_version().startswith(python_version):
+        # We need this path because in the development environment,
+        # the ray package is located in the source code directory
+        # in which the ray is compiled and installed by
+        # `pip install -e python/ --verbose`.
+        ray_package_path = get_ray_site_packages_path()
+
+    virtualenv_path = get_virtualenv_path(target_dir)
+    virtualenv_site_packages_path = os.path.join(
+        virtualenv_path, "lib", "python" + python_version, "site-packages"
+    )
+    all_packages = []
+    if ray_package_path:
+        all_packages.append(ray_package_path)
+    all_packages.append(host_site_packages_dir)
+    all_packages.append(virtualenv_site_packages_path)
+    return all_packages

--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -200,6 +200,9 @@ class WorkingDirPlugin(RuntimeEnvPlugin):
             )
         # Use placeholder here and will replace it by `pre_worker_startup`.
         working_dir = WorkingDirPlugin.working_dir_placeholder
+        # NOTE(Jacky): We need to set the working_dir in the context here, so that
+        # the container plugin can change the working dir placeholder to real working dir
+        context.working_dir = working_dir
         context.symlink_paths_to_working_dir.append(str(local_dir))
         context.env_vars[runtime_env_consts.RAY_WORKING_DIR] = working_dir
 
@@ -246,6 +249,11 @@ class WorkingDirPlugin(RuntimeEnvPlugin):
             context.env_vars[k] = v.replace(
                 WorkingDirPlugin.working_dir_placeholder, working_dir
             )
+        if "container_command" in context.container:
+            for i, command_str in enumerate(context.container["container_command"]):
+                context.container["container_command"][i] = command_str.replace(
+                    WorkingDirPlugin.working_dir_placeholder, working_dir
+                )
         # Add symbol links to the working dir.
         # Deduplicate, as linking duplicate file will raise FileExistsError
         linked_dir = set()

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -2130,3 +2130,13 @@ def check_library_usage_telemetry(
         assert all(
             [extra_usage_tags[k] == v for k, v in expected_extra_usage_tags.items()]
         ), extra_usage_tags
+
+
+def check_logs_by_keyword(keyword, log_file_pattern):
+    command = f'grep "{keyword}" -r ' f"/tmp/ray/session_latest/logs/{log_file_pattern}"
+    try:
+        result = subprocess.run(command, shell=True)
+        # If the grep command caught nothing, the return code should be 1.
+        return result.returncode == 0
+    except Exception:
+        return False

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -2196,7 +2196,7 @@ def try_parse_default_mount_points(mount_dict: Dict[str, str]):
             if len(parts) == 1:
                 mount_dict[parts[0]] = parts[0]
             elif len(parts) == 2:
-                mount_dict[parts[0]] = parts[1]
+                mount_dict[parts[1]] = parts[0]
             else:
                 raise RuntimeError(
                     f"Incorrect mount point, got '{mount_point}'"

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -2193,11 +2193,7 @@ def try_parse_default_mount_points(mount_dict: Dict[str, str]):
         default_mount_point_list = default_mount_points.split(";")
         for mount_point in default_mount_point_list:
             parts = mount_point.split(":")
-            if len(parts) == 1:
-                mount_dict[parts[0]] = parts[0]
-            elif len(parts) == 2:
-                mount_dict[parts[1]] = parts[0]
-            else:
+            if len(parts) != 2:
                 raise RuntimeError(
                     f"Incorrect mount point, got '{mount_point}'"
                     "please check the value of the environment variable `RAY_PODMAN_DEFAULT_MOUNT_POINTS`. "
@@ -2206,6 +2202,7 @@ def try_parse_default_mount_points(mount_dict: Dict[str, str]):
                     "For more details, please refer to the comments or documentation for the "
                     "`RAY_PODMAN_DEFAULT_MOUNT_POINTS` environment variable."
                 )
+            mount_dict[parts[1]] = parts[0]
 
     return mount_dict
 

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -385,13 +385,6 @@ class RuntimeEnv(dict):
                 "#create-env-file-manually"
             )
 
-        if self.get("container"):
-            logger.warning(
-                "The `container` runtime environment field is DEPRECATED and will be "
-                "removed after July 31, 2025. Use `image_uri` instead. See "
-                "https://docs.ray.io/en/latest/serve/advanced-guides/multi-app-container.html."  # noqa
-            )
-
         if self.get("container") and self.get("image_uri"):
             raise ValueError(
                 "'container' field and 'image_uri' field cannot be set at the same time."

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -386,18 +386,15 @@ class RuntimeEnv(dict):
             )
 
         if self.get("container"):
-            invalid_keys = set(runtime_env.keys()) - {"container", "config", "env_vars"}
-            if len(invalid_keys):
-                raise ValueError(
-                    "The 'container' field currently cannot be used "
-                    "together with other fields of runtime_env. "
-                    f"Specified fields: {invalid_keys}"
-                )
-
             logger.warning(
                 "The `container` runtime environment field is DEPRECATED and will be "
                 "removed after July 31, 2025. Use `image_uri` instead. See "
                 "https://docs.ray.io/en/latest/serve/advanced-guides/multi-app-container.html."  # noqa
+            )
+
+        if self.get("container") and self.get("image_uri"):
+            raise ValueError(
+                "'container' field and 'image_uri' field cannot be set at the same time."
             )
 
         if self.get("image_uri"):

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -1494,3 +1494,11 @@ def random_ascii_file(request):
         fp.flush()
 
         yield fp
+
+
+@pytest.fixture(scope="module")
+def set_runtime_env_container_default_mount_points(request):
+    default_mount_points = getattr(request, "param", "0")
+    os.environ["RAY_PODMAN_DEFAULT_MOUNT_POINTS"] = default_mount_points
+    yield default_mount_points
+    os.environ.pop("RAY_PODMAN_DEFAULT_MOUNT_POINTS", None)

--- a/python/ray/tests/test_runtime_env_container.py
+++ b/python/ray/tests/test_runtime_env_container.py
@@ -358,8 +358,8 @@ class TestContainerRuntimeEnvCommandLine:
     @pytest.mark.parametrize(
         "set_runtime_env_container_default_mount_points",
         [
-            "/tmp/fake_dir1;/tmp/fake_dir2",
-            "/tmp/fake_dir1:/tmp/fake_dir2;/tmp/fake_dir3",
+            "/tmp/fake_dir1:/tmp/fake_dir1;/tmp/fake_dir2:/tmp/fake_dir2",
+            "/tmp/fake_dir1:/tmp/fake_dir2;/tmp/fake_dir3:/tmp/fake_dir3",
             "/tmp/fake_dir1:/tmp/fake_dir2:/tmp/fake_dir3",
         ],
         indirect=True,
@@ -395,7 +395,10 @@ class TestContainerRuntimeEnvCommandLine:
         # Checkout the worker logs to ensure if the cgroup params is set correctly
         # in the podman command.
         log_file_pattern = "raylet.err"
-        if default_mount_points == "/tmp/fake_dir1;/tmp/fake_dir2":
+        if (
+            default_mount_points
+            == "/tmp/fake_dir1:/tmp/fake_dir1;/tmp/fake_dir2:/tmp/fake_dir2"
+        ):
             keyword1 = "\-v /tmp/fake_dir1:/tmp/fake_dir1"
             keyword2 = "\-v /tmp/fake_dir2:/tmp/fake_dir2"
             wait_for_condition(
@@ -405,7 +408,10 @@ class TestContainerRuntimeEnvCommandLine:
                 lambda: check_logs_by_keyword(keyword2, log_file_pattern), timeout=20
             )
 
-        elif default_mount_points == "/tmp/fake_dir1:/tmp/fake_dir2;/tmp/fake_dir3":
+        elif (
+            default_mount_points
+            == "/tmp/fake_dir1:/tmp/fake_dir2;/tmp/fake_dir3:/tmp/fake_dir3"
+        ):
             keyword1 = "\-v /tmp/fake_dir1:/tmp/fake_dir2"
             keyword2 = "\-v /tmp/fake_dir3:/tmp/fake_dir3"
             wait_for_condition(


### PR DESCRIPTION
## Why are these changes needed?

### Current Limitations
Ray's current Runtime Env mechanism allows users to specify dependencies (e.g., Python packages, files, or Conda environments) to be provisioned on worker nodes. However, when deploying Ray clusters in containerized environments (e.g., Docker, Kubernetes), users face significant challenges:

- Redundant Dependency Management:
Containers often already include pre-installed dependencies (e.g., system libraries, Python packages). Ray's current Runtime Env forces users to re-specify these dependencies, leading to redundant downloads, installation steps, and increased startup time.
- Inability to Leverage Base Images:
Users cannot directly reference a base container image as the foundation for their Ray workers. This limits the ability to:
    - Reuse pre-built environments for consistency and efficiency.
    - Isolate dependencies within a container's filesystem.
- Security and Resource Overhead:
Re-provisioning dependencies in containers may expose security risks (e.g., conflicting versions) or consume unnecessary resources.

### Technical Advantages of the Change
Implementing base worker support in containerized Runtime Envs would:

1. Improve Efficiency:
Allow Ray to inherit dependencies from the container's base image, eliminating redundant steps.
2. Enhance Security:
Ensure dependencies are pinned and validated at the container level, reducing conflicts.
3. Simplify Configuration:
Users could specify a base container image (e.g., my-ml-base:v1) in the Runtime Env, streamlining deployments.
4. Enable Advanced Use Cases:
Support scenarios like:
    - Multi-stage builds for optimized worker images.
    - Integration with Kubernetes Pod templates that rely on container-specific configurations.

### Proposed Approach
The proposed change would extend Runtime Env to accept a base container image as a foundational layer. For example:

```
ray.init(
    runtime_env={
        "container": {
            "image": "my-base-image:v1",  # Base container image
            "run_options": ["-v", "/host/path:/container/path"],  # Optional mounts
            "user": "admin", # base user
            "py_executable": "python", # user's python executable to execute ray worker in container
        },
        "pip": ["package1", "package2"],  # Additional dependencies
    }
)
```


## Related issue number

#570 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
