### PR TITLE
[VirtualCluster] Fix remove nodes from virtual cluster: return to primary cluster

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.cc
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.cc
@@ -162,7 +162,9 @@ Status VirtualCluster::RemoveNodeInstances(
       for (auto &[node_instance_id, node_instance] : node_instances) {
         auto removing_node_iter = node_set_to_remove.find(node_instance_id);
         if (removing_node_iter != node_set_to_remove.end() &&
-            IsNodeInstanceIdle(node_instance_id)) {
+            (!cluster_resource_manager_.HasNode(
+                 scheduling::NodeID(NodeID::FromHex(node_instance_id).Binary())) ||
+             IsNodeInstanceIdle(node_instance_id))) {
           (*removed_replica_instances)[template_id][job_id][node_instance_id] =
               node_instance;
           node_set_to_remove.erase(removing_node_iter);

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.cc
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.cc
@@ -153,17 +153,17 @@ void VirtualCluster::RemoveNodeInstances(ReplicaInstances replica_instances) {
 }
 
 Status VirtualCluster::RemoveNodeInstances(
-    const std::vector<std::string> &nodes_to_remove) {
+    const std::vector<std::string> &nodes_to_remove,
+    ReplicaInstances *removed_replica_instances) {
   absl::flat_hash_set<std::string> node_set_to_remove(nodes_to_remove.begin(),
                                                       nodes_to_remove.end());
-  ReplicaInstances replica_instances_to_remove;
   for (auto &[template_id, job_node_instances] : visible_node_instances_) {
     for (auto &[job_id, node_instances] : job_node_instances) {
       for (auto &[node_instance_id, node_instance] : node_instances) {
         auto removing_node_iter = node_set_to_remove.find(node_instance_id);
         if (removing_node_iter != node_set_to_remove.end() &&
             IsNodeInstanceIdle(node_instance_id)) {
-          replica_instances_to_remove[template_id][job_id][node_instance_id] =
+          (*removed_replica_instances)[template_id][job_id][node_instance_id] =
               node_instance;
           node_set_to_remove.erase(removing_node_iter);
         }
@@ -179,7 +179,7 @@ Status VirtualCluster::RemoveNodeInstances(
         std::any(nodes_with_failure));
   }
 
-  RemoveNodeInstances(replica_instances_to_remove);
+  RemoveNodeInstances(*removed_replica_instances);
   return Status::OK();
 }
 
@@ -960,11 +960,19 @@ Status PrimaryCluster::RemoveNodesFromVirtualCluster(
     const rpc::RemoveNodesFromVirtualClusterRequest &request,
     RemoveNodesFromVirtualClusterCallback callback) {
   auto logical_cluster = GetLogicalCluster(request.virtual_cluster_id());
-  auto status = logical_cluster->RemoveNodeInstances(std::vector<std::string>(
-      request.nodes_to_remove().begin(), request.nodes_to_remove().end()));
+  ReplicaInstances removed_replica_instances;
+  auto status = logical_cluster->RemoveNodeInstances(
+      std::vector<std::string>(request.nodes_to_remove().begin(),
+                               request.nodes_to_remove().end()),
+      &removed_replica_instances);
   if (!status.ok()) {
     return status;
   }
+
+  // Add the instances that just removed from the virtual cluster to the primary cluster.
+  UpdateNodeInstances(/*replica_instances_to_add=*/std::move(removed_replica_instances),
+                      /*replica_instances_to_remove=*/ReplicaInstances());
+
   return async_data_flusher_(logical_cluster->ToProto(), std::move(callback));
 }
 

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
@@ -258,7 +258,13 @@ class VirtualCluster {
   std::shared_ptr<NodeInstance> ReplenishUndividedNodeInstance(
       std::shared_ptr<NodeInstance> node_instance_to_replenish);
 
-  Status RemoveNodeInstances(const std::vector<std::string> &nodes_to_remove);
+  /// Remove specified nodes from a virtual cluster.
+  ///
+  /// \param nodes_to_remove The nodes to be removed.
+  /// \param removed_replica_instances The replica instances that actually removed based
+  /// on the `nodes_to_remove`. \return The status of the removal.
+  Status RemoveNodeInstances(const std::vector<std::string> &nodes_to_remove,
+                             ReplicaInstances *removed_replica_instances);
 
  protected:
   /// Insert the node instances to the cluster.

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
@@ -261,8 +261,9 @@ class VirtualCluster {
   /// Remove specified nodes from a virtual cluster.
   ///
   /// \param nodes_to_remove The nodes to be removed.
-  /// \param removed_replica_instances The replica instances that actually removed based
-  /// on the `nodes_to_remove`. \return The status of the removal.
+  /// \param removed_replica_instances The replica instances that were
+  /// actually removed based on the `nodes_to_remove`.
+  /// \return The status of the removal.
   Status RemoveNodeInstances(const std::vector<std::string> &nodes_to_remove,
                              ReplicaInstances *removed_replica_instances);
 

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
@@ -260,8 +260,8 @@ class VirtualCluster {
 
   /// Remove specified nodes from a virtual cluster.
   ///
-  /// \param nodes_to_remove The nodes to be removed.
-  /// \param removed_replica_instances The replica instances that were
+  /// \param[in] nodes_to_remove The nodes to be removed.
+  /// \param[out] removed_replica_instances The replica instances that were
   /// actually removed based on the `nodes_to_remove`.
   /// \return The status of the removal.
   Status RemoveNodeInstances(const std::vector<std::string> &nodes_to_remove,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, when removing nodes from a virtual cluster, their corresponding replica instances are not correctly returned to the primary cluster. This PR fixes this bug.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
#557 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
