### PR TITLE
[Autoscaler v2] Virtual cluster supports min/max autoscaling config

### DIFF
--- a/doc/source/virtual-cluster/management.rst
+++ b/doc/source/virtual-cluster/management.rst
@@ -216,3 +216,64 @@ To get the metadata of all virtual clusters, users can send a GET request to the
             ]
         }
     }
+
+Update Autoscaling Config
+-------------------------
+
+Users can update the autoscaling config (e.g., min/max limits) of a virtual cluster by sending a POST request to the http endpoint at `/virtual_clusters/update_autoscaling_config`.
+
+Once the autoscaling config is updated, the autoscaler (v2 only) will try to enforce it.
+
+**Sample Request:**
+
+.. code-block:: json
+
+    {
+        "virtualClusterId":"virtual_cluster_1",
+        "minReplicaSets":{ // The min replica sets of each node type.
+            "4c8g":1,
+            "8c16g":0
+        },
+        "maxReplicaSets":{ // The max replica sets of each node type.
+            "4c8g":2,
+            "8c16g":2
+        },
+        "maxNodes":4 // The max total node count
+    }
+
+**Sample Response:**
+
+.. code-block:: json
+
+    {
+        "result":true,
+        "msg":"Virtual cluster virtual_cluster_1's autoscaling config updated.",
+        "data":{
+            "virtualClusterId":"virtual_cluster_1"
+        }
+    }
+
+Get Autoscaling Config
+----------------------
+
+To get the autoscaling config of a virtual clusters, users can send a GET request to the http endpoint at `/virtual_clusters/autoscaling_config/{virtual_cluster_id}`.
+
+**Success Response:**
+
+.. code-block:: json
+
+    {
+        "result":true,
+        "msg":"Autoscaling config fetched.",
+        "data":{
+            "minReplicaSets":{
+                "4c8g":1,
+                "8c16g":0
+            },
+            "maxReplicaSets":{
+                "4c8g":2,
+                "8c16g":2
+            },
+            "maxNodes":4
+        }
+    }

--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -193,6 +193,7 @@ class VirtualClusterReconciler:
                 )
 
         node_type_configs = autoscaling_config.get_node_type_configs()
+        # Use the virtual cluster's min/max config.
         for _, config in node_type_configs.items():
             if config.ray_node_type in ray_state.min_replica_sets:
                 config.min_worker_nodes = ray_state.min_replica_sets[
@@ -201,6 +202,8 @@ class VirtualClusterReconciler:
                 config.max_worker_nodes = ray_state.max_replica_sets[
                     config.ray_node_type
                 ]
+            else:
+                config.min_worker_nodes = 0
 
         sched_request = SchedulingRequest(
             node_type_configs=node_type_configs,

--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -204,7 +204,9 @@ class VirtualClusterReconciler:
 
         sched_request = SchedulingRequest(
             node_type_configs=node_type_configs,
-            max_num_nodes=ray_state.max_nodes,
+            max_num_nodes=ray_state.max_nodes
+            if ray_state.max_nodes > 0
+            else autoscaling_config.get_max_num_nodes(),
             resource_requests=ray_state.pending_resource_requests,
             gang_resource_requests=ray_state.pending_gang_resource_requests,
             # For now, we don't support resource constraints at the virtual cluster level.

--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -193,9 +193,18 @@ class VirtualClusterReconciler:
                 )
 
         node_type_configs = autoscaling_config.get_node_type_configs()
+        for _, config in node_type_configs.items():
+            if config.ray_node_type in ray_state.min_replica_sets:
+                config.min_worker_nodes = ray_state.min_replica_sets[
+                    config.ray_node_type
+                ]
+                config.max_worker_nodes = ray_state.max_replica_sets[
+                    config.ray_node_type
+                ]
+
         sched_request = SchedulingRequest(
             node_type_configs=node_type_configs,
-            max_num_nodes=autoscaling_config.get_max_num_nodes(),
+            max_num_nodes=ray_state.max_nodes,
             resource_requests=ray_state.pending_resource_requests,
             gang_resource_requests=ray_state.pending_gang_resource_requests,
             # For now, we don't support resource constraints at the virtual cluster level.

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster.h
@@ -101,6 +101,8 @@ using RemoveVirtualClusterCallback = CreateOrUpdateVirtualClusterCallback;
 
 using RemoveNodesFromVirtualClusterCallback = CreateOrUpdateVirtualClusterCallback;
 
+using UpdateAutoscalingConfigCallback = CreateOrUpdateVirtualClusterCallback;
+
 using VirtualClustersDataVisitCallback =
     std::function<void(std::shared_ptr<rpc::VirtualClusterTableData>)>;
 
@@ -173,6 +175,12 @@ class VirtualCluster {
   const ReplicaInstances &GetVisibleNodeInstances() const {
     return visible_node_instances_;
   }
+
+  const ReplicaSets &GetMinReplicaSets() const { return min_replica_sets_; }
+
+  const ReplicaSets &GetMaxReplicaSets() const { return max_replica_sets_; }
+
+  int32_t GetMaxNodes() const { return max_nodes_; }
 
   /// Update the node instances of the cluster.
   ///
@@ -267,6 +275,10 @@ class VirtualCluster {
   Status RemoveNodeInstances(const std::vector<std::string> &nodes_to_remove,
                              ReplicaInstances *removed_replica_instances);
 
+  Status UpdateAutoscalingConfig(const ReplicaSets &min_replica_sets,
+                                 const ReplicaSets &max_replica_sets,
+                                 int32_t max_ndoes);
+
  protected:
   /// Insert the node instances to the cluster.
   ///
@@ -293,6 +305,9 @@ class VirtualCluster {
   /// instance.
   absl::flat_hash_map<std::string, std::shared_ptr<NodeInstance>> node_instances_map_;
   const ClusterResourceManager &cluster_resource_manager_;
+  ReplicaSets min_replica_sets_;
+  ReplicaSets max_replica_sets_;
+  int32_t max_nodes_;
 };
 
 class JobCluster;
@@ -493,6 +508,10 @@ class PrimaryCluster : public DivisibleCluster,
   Status RemoveNodesFromVirtualCluster(
       const rpc::RemoveNodesFromVirtualClusterRequest &request,
       RemoveNodesFromVirtualClusterCallback callback);
+
+  Status UpdateVirtualClusterAutoscalingConfig(
+      const rpc::UpdateAutoscalingConfigRequest &request,
+      UpdateAutoscalingConfigCallback callback);
 
   /// Get the virtual cluster by the logical cluster id.
   ///

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster_autoscaler_state_manager.cc
@@ -95,6 +95,13 @@ void GcsVirtualClusterAutoscalerStateManager::MakeVirtualClusterResourceStatesIn
           // Collect the pending resource requests in this virtual cluster.
           GetVirtualClusterPendingResourceRequests(&virtual_cluster_state);
         }
+        virtual_cluster_state.mutable_min_replica_sets()->insert(
+            virtual_cluster->GetMinReplicaSets().begin(),
+            virtual_cluster->GetMinReplicaSets().end());
+        virtual_cluster_state.mutable_max_replica_sets()->insert(
+            virtual_cluster->GetMaxReplicaSets().begin(),
+            virtual_cluster->GetMaxReplicaSets().end());
+        virtual_cluster_state.set_max_nodes(virtual_cluster->GetMaxNodes());
 
         (*virtual_cluster_states)[virtual_cluster->GetID()] = virtual_cluster_state;
       });

--- a/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_virtual_cluster_manager.h
@@ -119,11 +119,21 @@ class GcsVirtualClusterManager : public rpc::VirtualClusterInfoHandler {
       rpc::GetAllVirtualClusterInfoReply *reply,
       rpc::SendReplyCallback send_reply_callback) override;
 
+  void HandleUpdateAutoscalingConfig(rpc::UpdateAutoscalingConfigRequest request,
+                                     rpc::UpdateAutoscalingConfigReply *reply,
+                                     rpc::SendReplyCallback send_reply_callback) override;
+
+  void HandleGetAutoscalingConfig(rpc::GetAutoscalingConfigRequest request,
+                                  rpc::GetAutoscalingConfigReply *reply,
+                                  rpc::SendReplyCallback send_reply_callback) override;
+
   Status VerifyRequest(const rpc::CreateOrUpdateVirtualClusterRequest &request);
 
   Status VerifyRequest(const rpc::RemoveNodesFromVirtualClusterRequest &request);
 
   Status VerifyRequest(const rpc::RemoveVirtualClusterRequest &request);
+
+  Status VerifyRequest(const rpc::UpdateAutoscalingConfigRequest &request);
 
   Status FlushAndPublish(std::shared_ptr<rpc::VirtualClusterTableData> data,
                          CreateOrUpdateVirtualClusterCallback callback);

--- a/src/ray/protobuf/autoscaler.proto
+++ b/src/ray/protobuf/autoscaler.proto
@@ -181,6 +181,9 @@ message VirtualClusterState {
   repeated ResourceRequestByCount pending_resource_requests = 5;
   // Gang resource requests pending scheduling.
   repeated GangResourceRequest pending_gang_resource_requests = 6;
+  map<string, int32> min_replica_sets = 7;
+  map<string, int32> max_replica_sets = 8;
+  int32 max_nodes = 9;
 }
 
 // Represents a cluster resource state.

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -732,4 +732,8 @@ message VirtualClusterTableData {
   bool is_removed = 4;
   // Version number of the last modification to the virtual cluster.
   uint64 revision = 5;
+
+  map<string, int32> min_replica_sets = 6;
+  map<string, int32> max_replica_sets = 7;
+  int32 max_nodes = 8;
 }

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -984,6 +984,28 @@ message CreateJobClusterReply {
   map<string, int32> replica_sets_to_recommend = 3;
 }
 
+message UpdateAutoscalingConfigRequest {
+  string virtual_cluster_id = 1;
+  map<string, int32> min_replica_sets = 2;
+  map<string, int32> max_replica_sets = 3;
+  int32 max_nodes = 4;
+}
+
+message UpdateAutoscalingConfigReply {
+  GcsStatus status = 1;
+}
+
+message GetAutoscalingConfigRequest {
+  string virtual_cluster_id = 1;
+}
+
+message GetAutoscalingConfigReply {
+  GcsStatus status = 1;
+  map<string, int32> min_replica_sets = 2;
+  map<string, int32> max_replica_sets = 3;
+  int32 max_nodes = 4;
+}
+
 service VirtualClusterInfoGcsService {
   // Create or update a virtual cluster.
   rpc CreateOrUpdateVirtualCluster(CreateOrUpdateVirtualClusterRequest)
@@ -1001,4 +1023,6 @@ service VirtualClusterInfoGcsService {
   // Get all virtual clusters info for display.
   rpc GetAllVirtualClusterInfo(GetAllVirtualClusterInfoRequest)
       returns (GetAllVirtualClusterInfoReply);
+  rpc UpdateAutoscalingConfig(UpdateAutoscalingConfigRequest) returns (UpdateAutoscalingConfigReply);
+  rpc GetAutoscalingConfig(GetAutoscalingConfigRequest) returns (GetAutoscalingConfigReply);
 }

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -599,6 +599,16 @@ class GcsRpcClient {
                              virtual_cluster_info_grpc_client_,
                              /*method_timeout_ms*/ -1, )
 
+  VOID_GCS_RPC_CLIENT_METHOD(VirtualClusterInfoGcsService,
+                             UpdateAutoscalingConfig,
+                             virtual_cluster_info_grpc_client_,
+                             /*method_timeout_ms*/ -1, )
+
+  VOID_GCS_RPC_CLIENT_METHOD(VirtualClusterInfoGcsService,
+                             GetAutoscalingConfig,
+                             virtual_cluster_info_grpc_client_,
+                             /*method_timeout_ms*/ -1, )
+
   std::pair<std::string, int64_t> GetAddress() const {
     return std::make_pair(gcs_address_, gcs_port_);
   }

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -754,6 +754,14 @@ class VirtualClusterInfoGcsServiceHandler {
   virtual void HandleGetAllVirtualClusterInfo(GetAllVirtualClusterInfoRequest request,
                                               GetAllVirtualClusterInfoReply *reply,
                                               SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleUpdateAutoscalingConfig(UpdateAutoscalingConfigRequest request,
+                                             UpdateAutoscalingConfigReply *reply,
+                                             SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleGetAutoscalingConfig(GetAutoscalingConfigRequest request,
+                                          GetAutoscalingConfigReply *reply,
+                                          SendReplyCallback send_reply_callback) = 0;
 };
 
 class VirtualClusterInfoGrpcService : public GrpcService {
@@ -778,6 +786,8 @@ class VirtualClusterInfoGrpcService : public GrpcService {
     VIRTUAL_CLUSTER_SERVICE_RPC_HANDLER(GetVirtualClusters);
     VIRTUAL_CLUSTER_SERVICE_RPC_HANDLER(CreateJobCluster);
     VIRTUAL_CLUSTER_SERVICE_RPC_HANDLER(GetAllVirtualClusterInfo);
+    VIRTUAL_CLUSTER_SERVICE_RPC_HANDLER(UpdateAutoscalingConfig);
+    VIRTUAL_CLUSTER_SERVICE_RPC_HANDLER(GetAutoscalingConfig);
   }
 
  private:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With this PR, users can set the min/max limits for each node type of a virtual cluster.

## Related issue number
#506 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
