### PR TITLE
[FlowInsight] Fix the dashboard after GcsAioClient and GcsClient unified

### DIFF
--- a/python/ray/dashboard/modules/insight/insight_head.py
+++ b/python/ray/dashboard/modules/insight/insight_head.py
@@ -7,7 +7,6 @@ import ray.dashboard.optional_utils as dashboard_optional_utils
 from ray.dashboard.modules.node.datacenter import DataSource
 from ray._private.test_utils import get_resource_usage
 from ray.dashboard.utils import async_loop_forever
-import ray._private.ray_constants as ray_constants
 from ray.dashboard.modules.insight.insight_prompt import PROMPT_TEMPLATE
 from flow_insight import (
     BatchNodePhysicalStatsEvent,
@@ -66,7 +65,7 @@ class InsightHead(dashboard_utils.DashboardHeadModule):
 
     @async_loop_forever(10)
     async def _emit_node_physical_stats(self):
-        insight_server_address = await self.gcs_aio_client.internal_kv_get(
+        insight_server_address = await self.gcs_client.async_internal_kv_get(
             "insight_monitor_address",
             namespace="flowinsight",
             timeout=5,
@@ -240,7 +239,7 @@ class InsightHead(dashboard_utils.DashboardHeadModule):
             query_string = req.query_string
 
             if self._insight_server_address is None:
-                insight_server_address = await self.gcs_aio_client.internal_kv_get(
+                insight_server_address = await self.gcs_client.async_internal_kv_get(
                     "insight_monitor_address",
                     namespace="flowinsight",
                     timeout=5,
@@ -255,7 +254,7 @@ class InsightHead(dashboard_utils.DashboardHeadModule):
 
             if not await self.is_insight_server_alive():
                 self._insight_server_address = (
-                    await self.gcs_aio_client.internal_kv_get(
+                    await self.gcs_client.async_internal_kv_get(
                         "insight_monitor_address",
                         namespace="flowinsight",
                         timeout=5,


### PR DESCRIPTION
This PR tries to fix the dashboard after #52735

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

After  #52735, the current branch actually cannot run flow insight:
~~~
2025-08-12 00:24:53,675 ERROR utils.py:631 -- Error looping coroutine <function InsightHead._emit_node_physical_stats at 0x120745430>.
Traceback (most recent call last):
File "/Users/xx/Documents/github/ant-ray/python/ray/dashboard/utils.py", line 618, in _looper
await coro(*args, **kwargs)
File "/Users/xx/Documents/github/ant-ray/python/ray/dashboard/modules/insight/insight_head.py", line 69, in _emit_node_physical_stats
insight_server_address = await self.gcs_aio_client.internal_kv_get(
AttributeError: 'InsightHead' object has no attribute 'gcs_aio_client'
~~~
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(

## Summary by Sourcery

Replace deprecated gcs_aio_client.internal_kv_get calls in InsightHead with gcs_client.async_internal_kv_get to restore dashboard functionality after GcsClient unification

Bug Fixes:
- Fix missing gcs_aio_client attribute in InsightHead by switching to gcs_client.async_internal_kv_get when emitting node physical stats
- Fix proxy request logic in InsightHead to use gcs_client.async_internal_kv_get for fetching insight_monitor_address